### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Speak to Lichess in natural language to interact with the chess platform. Use it
 
 Built using the [Model Context Protocol](https://github.com/modelcontextprotocol).
 
+<a href="https://glama.ai/mcp/servers/x7iuw37s1v">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/x7iuw37s1v/badge" alt="Lichess MCP server" />
+</a>
+
 The server enables:
 
 - Managing your Lichess account


### PR DESCRIPTION
This PR adds a badge for the [Lichess MCP](https://glama.ai/mcp/servers/x7iuw37s1v) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/x7iuw37s1v">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/x7iuw37s1v/badge" alt="Lichess MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.