### PR TITLE
feat: interactive MCP Apps UIs for puzzles, PGN viewer, and opening explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ create_arena({
 });
 ```
 
+### 5. Interactive UIs (Claude Desktop)
+
+These tools open a real chess board inside the chat — drag pieces, navigate
+moves, and click through opening trees — using the [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview)
+extension. In clients without UI support, each tool falls back to a
+text response containing FEN/PGN/Lichess links.
+
+```typescript
+// Open today's daily puzzle (or a specific id) as an interactive solver.
+play_puzzle({ puzzleId: "Bmfot" });
+
+// Step through a Lichess game or raw PGN with prev/next/play controls.
+view_pgn({ gameId: "abcd1234" });
+view_pgn({ pgn: "1. e4 e5 2. Nf3 ..." });
+
+// Walk the opening tree: click moves to drill down; toggle masters/lichess.
+explore_openings({ source: "masters" });
+```
+
 ## Chess Notation
 
 ### Move Formats

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "lichess-mcp",
       "version": "0.2.0",
       "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "chess.js": "^1.4.0",
         "dotenv": "^16.3.1",
         "zod": "^4.3.6"
       },
@@ -18,7 +20,10 @@
       "devDependencies": {
         "@types/node": ">=22.12.0",
         "@vitest/coverage-v8": "^3.2.4",
+        "chessground": "^9.2.1",
         "typescript": "^5.3.3",
+        "vite": "^8.0.10",
+        "vite-plugin-singlefile": "^2.3.3",
         "vitest": "^3.2.4"
       }
     },
@@ -94,6 +99,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -617,6 +656,35 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.1.tgz",
+      "integrity": "sha512-J3WdG1A4JSSKnSWKyU+895dBVYBV2Utgtf7fUsUK45mlkETm53a/1DR6Pm3hUGKqLLQthZLmpxOg8VPzJi/lyg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -657,6 +725,35 @@
         }
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -667,6 +764,270 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1017,6 +1378,23 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1382,6 +1760,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1455,6 +1846,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/chessground": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/chessground/-/chessground-9.2.1.tgz",
+      "integrity": "sha512-KIdxm0zD69e62XRwdnFB0XUNYSzn5HM3pMazRCwpfruRUowFI8y+1OAK5YSyBff29myeV1/4o5Q8T191+Irbog==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "GPL-3.0-or-later",
+      "funding": {
+        "url": "https://lichess.org/patron"
       }
     },
     "node_modules/color-convert": {
@@ -1582,6 +1990,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -1900,6 +2318,19 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2204,6 +2635,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2314,6 +2755,267 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2394,6 +3096,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/minimatch": {
@@ -2684,6 +3413,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/rollup": {
@@ -3201,6 +3964,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3209,6 +3985,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -3286,6 +4070,84 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite-node": {
@@ -3382,6 +4244,28 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-singlefile": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.3.tgz",
+      "integrity": "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">18.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^4.59.0",
+        "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,13 @@
     "build"
   ],
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "build:ui:puzzle": "UI_TARGET=puzzle vite build && mv build/ui/index.html build/ui/puzzle.html",
+    "build:ui:pgn": "UI_TARGET=pgn vite build && mv build/ui/index.html build/ui/pgn.html",
+    "build:ui:openings": "UI_TARGET=openings vite build && mv build/ui/index.html build/ui/openings.html",
+    "build:ui": "npm run build:ui:puzzle && npm run build:ui:pgn && npm run build:ui:openings",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.ui.json",
+    "build:server": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "build": "npm run typecheck && npm run build:ui && npm run build:server",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
@@ -21,14 +27,19 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.7.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "chess.js": "^1.4.0",
     "dotenv": "^16.3.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": ">=22.12.0",
     "@vitest/coverage-v8": "^3.2.4",
+    "chessground": "^9.2.1",
     "typescript": "^5.3.3",
+    "vite": "^8.0.10",
+    "vite-plugin-singlefile": "^2.3.3",
     "vitest": "^3.2.4"
   }
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,6 +1,14 @@
 import { z, ZodObject, ZodRawShape } from "zod";
 import { LichessClient } from "./http/client.js";
 import { TokenStore } from "./http/token-store.js";
+import { UiToolResult } from "./types/ui-props.js";
+
+/**
+ * Mirror of the MCP Apps spec type
+ * (`@modelcontextprotocol/ext-apps` `McpUiToolVisibility`). Inlined because the
+ * package's root re-export isn't reachable under Node16 module resolution.
+ */
+export type McpUiToolVisibility = "model" | "app";
 
 export interface ToolContext {
   client: LichessClient;
@@ -8,11 +16,35 @@ export interface ToolContext {
 }
 
 /**
- * Tools return either a string (rendered as plain text) or any JSON-serializable
- * value (rendered via JSON.stringify). The dispatcher in server.ts wraps the
- * return value into the MCP `CallToolResult` shape.
+ * Tools return either a string (rendered as plain text), any JSON-serializable
+ * value (rendered via JSON.stringify), or a UiToolResult discriminator that
+ * carries both a text fallback and structured props for an MCP App iframe.
+ * The dispatcher in server.ts unwraps each shape into the MCP `CallToolResult`.
  */
-export type ToolResult = string | object;
+export type ToolResult = string | object | UiToolResult<unknown>;
+
+/**
+ * Optional MCP Apps descriptor — a tool with this set is registered via
+ * `registerAppTool`, so it carries `_meta.ui` to MCP-Apps-aware clients.
+ *
+ * Two shapes are supported:
+ * - Iframe-bearing tool: set `resourceUri` + `htmlFile` (and optionally `csp`).
+ * - App-only callback: omit `resourceUri`/`htmlFile` and set `visibility: ["app"]`
+ *   so the tool is invisible to the model and callable only from this server's iframe.
+ */
+export interface UiAppDescriptor {
+  /** Stable URI like "ui://lichess-mcp/puzzle.html". Omit for app-only callback tools. */
+  resourceUri?: string;
+  /** Filename inside build/ui/ produced by Vite (e.g. "puzzle.html"). Required iff resourceUri is set. */
+  htmlFile?: string;
+  /** Optional CSP overrides — leave undefined for fully self-contained UIs. */
+  csp?: { resourceDomains?: string[]; connectDomains?: string[] };
+  /**
+   * MCP Apps visibility per spec. Default (omitted) is `["model", "app"]`.
+   * Use `["app"]` for iframe-only callbacks the model must not invoke directly.
+   */
+  visibility?: McpUiToolVisibility[];
+}
 
 export interface ToolDefinition<S extends ZodRawShape = ZodRawShape> {
   name: string;
@@ -20,6 +52,8 @@ export interface ToolDefinition<S extends ZodRawShape = ZodRawShape> {
   /** Object-shape schema. The shape is what gets passed to MCP for validation. */
   schema: ZodObject<S>;
   handler: (args: z.infer<ZodObject<S>>, ctx: ToolContext) => Promise<ToolResult>;
+  /** When set, the tool is registered as an MCP App with this UI resource. */
+  ui?: UiAppDescriptor;
 }
 
 /**
@@ -33,4 +67,13 @@ export type AnyToolDefinition = ToolDefinition<any>;
 /** Identity helper that preserves the schema's generic so handler args stay typed. */
 export function tool<S extends ZodRawShape>(definition: ToolDefinition<S>): ToolDefinition<S> {
   return definition;
+}
+
+/** Type guard for handler returns that carry MCP App UI props. */
+export function isUiResult(value: unknown): value is UiToolResult<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __uiResult?: unknown }).__uiResult === true
+  );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,20 +1,75 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  registerAppTool,
+  registerAppResource,
+  RESOURCE_MIME_TYPE,
+} from "@modelcontextprotocol/ext-apps/server";
 import { z, ZodError } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { LichessApiError } from "./http/errors.js";
-import { AnyToolDefinition, ToolContext, ToolResult } from "./registry.js";
+import {
+  AnyToolDefinition,
+  ToolContext,
+  ToolResult,
+  isUiResult,
+} from "./registry.js";
 import { allTools } from "./tools/index.js";
 import { registerPrompts } from "./prompts/index.js";
+import { readUiHtml } from "./ui-loader.js";
+import { UI_META_KEY } from "./types/ui-props.js";
 
 export function buildServer(ctx: ToolContext): McpServer {
   const mcp = new McpServer({ name: "lichess-mcp", version: "0.2.0" });
 
+  // De-dupe resource registrations across multiple tools that share a UI.
+  const registeredResources = new Set<string>();
+
   for (const t of allTools) {
-    mcp.registerTool(
-      t.name,
-      { description: t.description, inputSchema: t.schema.shape },
-      async (args: unknown) => runTool(t, args, ctx),
-    );
+    if (t.ui) {
+      const ui = t.ui;
+      const uiMeta: { resourceUri?: string; visibility?: typeof ui.visibility } = {};
+      if (ui.resourceUri) uiMeta.resourceUri = ui.resourceUri;
+      if (ui.visibility) uiMeta.visibility = ui.visibility;
+
+      registerAppTool(
+        mcp,
+        t.name,
+        {
+          description: t.description,
+          inputSchema: t.schema.shape,
+          _meta: { ui: uiMeta },
+        },
+        async (args: unknown) => runTool(t, args, ctx),
+      );
+
+      if (ui.resourceUri && ui.htmlFile && !registeredResources.has(ui.resourceUri)) {
+        const resourceUri = ui.resourceUri;
+        const htmlFile = ui.htmlFile;
+        registeredResources.add(resourceUri);
+        registerAppResource(
+          mcp,
+          `${t.name} UI`,
+          resourceUri,
+          {},
+          async () => ({
+            contents: [
+              {
+                uri: resourceUri,
+                mimeType: RESOURCE_MIME_TYPE,
+                text: readUiHtml(htmlFile),
+                ...(ui.csp ? { _meta: { ui: { csp: ui.csp } } } : {}),
+              },
+            ],
+          }),
+        );
+      }
+    } else {
+      mcp.registerTool(
+        t.name,
+        { description: t.description, inputSchema: t.schema.shape },
+        async (args: unknown) => runTool(t, args, ctx),
+      );
+    }
   }
 
   registerPrompts(mcp);
@@ -54,6 +109,12 @@ export async function runTool(
 }
 
 function successResult(value: ToolResult): CallToolResult {
+  if (isUiResult(value)) {
+    return {
+      content: [{ type: "text", text: value.text }],
+      _meta: { [UI_META_KEY]: { props: value.props } },
+    };
+  }
   const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
   return { content: [{ type: "text", text }] };
 }

--- a/src/tools/apps/explore-openings.ts
+++ b/src/tools/apps/explore-openings.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import { Chess } from "chess.js";
+import { tool } from "../../registry.js";
+import {
+  fetchLichessExplorer,
+  fetchMastersExplorer,
+} from "../opening-explorer.js";
+import type {
+  ExplorerData,
+  ExplorerSource,
+  OpeningsProps,
+  UiToolResult,
+} from "../../types/ui-props.js";
+
+const STARTING_FEN =
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+function applyPlay(rootFen: string, play: string): string {
+  if (!play) return rootFen;
+  const chess = new Chess(rootFen);
+  for (const uci of play.split(",")) {
+    if (!uci) continue;
+    const from = uci.slice(0, 2);
+    const to = uci.slice(2, 4);
+    const promotion = uci.length > 4 ? uci.slice(4, 5) : undefined;
+    const move = chess.move({ from, to, promotion });
+    if (!move) throw new Error(`Illegal move in play: ${uci}`);
+  }
+  return chess.fen();
+}
+
+function summarizeText(data: ExplorerData, source: ExplorerSource): string {
+  const total = data.white + data.draws + data.black;
+  const lines: string[] = [];
+  if (data.opening?.name) lines.push(`Opening: ${data.opening.name}`);
+  lines.push(`Source: ${source} · ${total.toLocaleString()} games`);
+  lines.push(`White ${data.white} · Draws ${data.draws} · Black ${data.black}`);
+  lines.push("");
+  lines.push("Top moves:");
+  const top = (data.moves ?? []).slice(0, 5);
+  for (const m of top) {
+    const t = m.white + m.draws + m.black;
+    const pct = (n: number) => (t === 0 ? 0 : Math.round((n / t) * 100));
+    lines.push(
+      `  ${m.san.padEnd(7)} ${t.toLocaleString().padStart(8)}  ` +
+        `W ${pct(m.white)}% · D ${pct(m.draws)}% · B ${pct(m.black)}%`,
+    );
+  }
+  return lines.join("\n");
+}
+
+export const exploreOpenings = tool({
+  name: "explore_openings",
+  description:
+    "Open an interactive opening explorer in Claude Desktop. Click moves on the board or in the move list to drill down; switch between Masters (OTB) and Lichess game databases. Defaults to the starting position.",
+  schema: z.object({
+    fen: z
+      .string()
+      .optional()
+      .describe("Root position FEN (default: starting position)."),
+    play: z
+      .string()
+      .optional()
+      .describe("Comma-separated UCI moves to apply from `fen`."),
+    source: z
+      .enum(["masters", "lichess"])
+      .default("masters")
+      .describe("Which game database to query."),
+  }),
+  ui: {
+    resourceUri: "ui://lichess-mcp/openings.html",
+    htmlFile: "openings.html",
+  },
+  handler: async ({ fen, play, source }, { client }) => {
+    const rootFen = fen ?? STARTING_FEN;
+    const playStr = play ?? "";
+    const currentFen = applyPlay(rootFen, playStr);
+
+    const initialData =
+      source === "lichess"
+        ? await fetchLichessExplorer<ExplorerData>(
+            { fen: rootFen, play: playStr, moves: 12, topGames: 4 },
+            client,
+          )
+        : await fetchMastersExplorer<ExplorerData>(
+            { fen: rootFen, play: playStr, moves: 12, topGames: 4 },
+            client,
+          );
+
+    const props: OpeningsProps = {
+      rootFen,
+      play: playStr,
+      currentFen,
+      source,
+      initialData,
+    };
+
+    const result: UiToolResult<OpeningsProps> = {
+      __uiResult: true,
+      text: summarizeText(initialData, source),
+      props,
+    };
+    return result;
+  },
+});

--- a/src/tools/apps/index.ts
+++ b/src/tools/apps/index.ts
@@ -1,0 +1,21 @@
+import { AnyToolDefinition } from "../../registry.js";
+import { exploreOpenings } from "./explore-openings.js";
+import { playPuzzle } from "./play-puzzle.js";
+import { submitPuzzleBatch } from "./submit-puzzle-batch.js";
+import { viewPgn } from "./view-pgn.js";
+
+/**
+ * Interactive UI tools registered as MCP Apps. Each renders an iframe in
+ * MCP-Apps-capable hosts (e.g. Claude Desktop) and falls back to the text
+ * `content` field for clients without UI support.
+ *
+ * `submitPuzzleBatch` is an iframe-only callback: it carries
+ * `ui: { visibility: ["app"] }` so MCP-Apps hosts hide it from the model and
+ * only the play_puzzle iframe can invoke it via callServerTool.
+ */
+export const appTools: AnyToolDefinition[] = [
+  playPuzzle,
+  viewPgn,
+  exploreOpenings,
+  submitPuzzleBatch,
+];

--- a/src/tools/apps/play-puzzle.ts
+++ b/src/tools/apps/play-puzzle.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+import { Chess } from "chess.js";
+import { tool } from "../../registry.js";
+import type {
+  Color,
+  PuzzleProps,
+  PuzzleSpec,
+  UiToolResult,
+} from "../../types/ui-props.js";
+
+interface LichessPuzzlePayload {
+  game?: { id?: string; pgn?: string };
+  puzzle?: {
+    id?: string;
+    initialPly?: number;
+    fen?: string;
+    solution?: string[];
+    themes?: string[];
+    rating?: number;
+  };
+}
+
+interface PuzzleBatchResponse {
+  puzzles?: LichessPuzzlePayload[];
+}
+
+/**
+ * Replay the game's PGN to the position the puzzle starts from.
+ *
+ * Lichess convention: `initialPly` is the index of the LAST played half-move
+ * before the user's first move. The opponent has just moved, and now it's
+ * the user's turn — so the side to move at this FEN is the user's color.
+ */
+function fenAtPuzzleStart(
+  pgn: string,
+  initialPly: number,
+  puzzleId: string,
+): { fen: string; color: Color } {
+  const chess = new Chess();
+  try {
+    chess.loadPgn(pgn);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`Puzzle ${puzzleId} has an invalid PGN: ${reason}`);
+  }
+  const history = chess.history({ verbose: true });
+  const replay = new Chess();
+  for (let i = 0; i < initialPly + 1 && i < history.length; i++) {
+    replay.move({
+      from: history[i].from,
+      to: history[i].to,
+      promotion: history[i].promotion,
+    });
+  }
+  const fen = replay.fen();
+  const color: Color = fen.split(" ")[1] === "w" ? "white" : "black";
+  return { fen, color };
+}
+
+function specFromPayload(payload: LichessPuzzlePayload, fallbackId = "puzzle"): PuzzleSpec {
+  const id = payload.puzzle?.id ?? fallbackId;
+  const solution = payload.puzzle?.solution ?? [];
+  const themes = payload.puzzle?.themes ?? [];
+  const rating = payload.puzzle?.rating ?? null;
+  const lichessUrl = `https://lichess.org/training/${id}`;
+
+  let fen: string;
+  let orientation: Color;
+  if (payload.puzzle?.fen) {
+    fen = payload.puzzle.fen;
+    orientation = fen.split(" ")[1] === "w" ? "white" : "black";
+  } else {
+    const pgn = payload.game?.pgn ?? "";
+    const initialPly = payload.puzzle?.initialPly ?? 0;
+    ({ fen, color: orientation } = fenAtPuzzleStart(pgn, initialPly, id));
+  }
+
+  return { puzzleId: id, fen, solution, orientation, themes, rating, lichessUrl };
+}
+
+export const playPuzzle = tool({
+  name: "play_puzzle",
+  description:
+    "Open an interactive chess puzzle in Claude Desktop. Drag pieces to solve; the UI validates each move against the Lichess solution and auto-plays the opponent's reply. " +
+    "Default: today's daily puzzle. Use {next:true} for an unseen puzzle, {puzzleId} for a specific one, or {rated:true, nb:N, angle:'mix'} to start a RATED batch session that updates your Lichess puzzle rating when completed.",
+  schema: z.object({
+    puzzleId: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Lichess puzzle id."),
+    next: z
+      .boolean()
+      .optional()
+      .describe(
+        "Fetch a fresh non-daily puzzle (Lichess /puzzle/next). Used by the iframe's Next button.",
+      ),
+    rated: z
+      .boolean()
+      .optional()
+      .describe(
+        "Start a rated batch session. The iframe walks through `nb` puzzles, then submits the results to /puzzle/batch/{angle} so they affect your Lichess rating. Requires the puzzle:write OAuth scope.",
+      ),
+    angle: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Theme/angle for the batch (default: 'mix'). Only used in rated mode."),
+    nb: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe("Number of puzzles in the rated batch (default: 10, max 50)."),
+    difficulty: z
+      .enum(["easiest", "easier", "normal", "harder", "hardest"])
+      .optional()
+      .describe("Difficulty band relative to the user's current rating (rated mode only)."),
+    color: z
+      .enum(["white", "black"])
+      .optional()
+      .describe("Force playing as a single color (only honored when nb=1)."),
+  }),
+  ui: {
+    resourceUri: "ui://lichess-mcp/puzzle.html",
+    htmlFile: "puzzle.html",
+  },
+  handler: async (args, { client }) => {
+    if (args.rated) {
+      const angle = args.angle ?? "mix";
+      const nb = args.nb ?? 10;
+      const params = new URLSearchParams();
+      params.set("nb", String(nb));
+      if (args.difficulty) params.set("difficulty", args.difficulty);
+      if (args.color && nb === 1) params.set("color", args.color);
+      const data = await client.json<PuzzleBatchResponse>(
+        `/puzzle/batch/${encodeURIComponent(angle)}?${params.toString()}`,
+      );
+      const puzzles = (data.puzzles ?? []).map((p, i) =>
+        specFromPayload(p, `${angle}-${i}`),
+      );
+
+      const props: PuzzleProps = {
+        puzzles,
+        session: { angle, rated: true },
+      };
+      const text = [
+        `Rated batch: ${puzzles.length} puzzle${puzzles.length === 1 ? "" : "s"} (angle ${angle}).`,
+        `Solve them in the interactive UI to update your Lichess puzzle rating.`,
+        ...puzzles.map(
+          (p, i) =>
+            `  ${i + 1}. ${p.puzzleId}${p.rating ? ` (${p.rating})` : ""} — ${p.lichessUrl}`,
+        ),
+      ].join("\n");
+
+      const result: UiToolResult<PuzzleProps> = { __uiResult: true, text, props };
+      return result;
+    }
+
+    // Single-puzzle mode (daily / next / by-id).
+    const path = args.puzzleId
+      ? `/puzzle/${encodeURIComponent(args.puzzleId)}`
+      : args.next
+        ? "/puzzle/next"
+        : "/puzzle/daily";
+    const data = await client.json<LichessPuzzlePayload>(path);
+    const spec = specFromPayload(data, args.puzzleId ?? "daily");
+
+    const props: PuzzleProps = {
+      puzzles: [spec],
+      session: { angle: "", rated: false },
+    };
+    const text = [
+      `Puzzle ${spec.puzzleId}${spec.rating ? ` (rating ${spec.rating})` : ""}.`,
+      spec.themes.length ? `Themes: ${spec.themes.join(", ")}.` : "",
+      `Open: ${spec.lichessUrl}`,
+      `FEN: ${spec.fen}`,
+      `Solution (UCI): ${spec.solution.join(" ")}`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const result: UiToolResult<PuzzleProps> = { __uiResult: true, text, props };
+    return result;
+  },
+});

--- a/src/tools/apps/submit-puzzle-batch.ts
+++ b/src/tools/apps/submit-puzzle-batch.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { tool } from "../../registry.js";
+
+/**
+ * POST /api/puzzle/batch/{angle} — "Set puzzles as solved and update ratings."
+ *
+ * Called by the puzzle iframe after the user finishes a rated session. The
+ * iframe receives back per-puzzle ratingDiff values plus the new glicko rating
+ * and renders them as a results panel. There is no UI resource of its own.
+ */
+export const submitPuzzleBatch = tool({
+  name: "submit_puzzle_batch",
+  description:
+    "Internal callback for the play_puzzle iframe to submit a completed rated batch and update the user's puzzle rating. Not exposed to the model — see solve_puzzle_batch for the model-callable equivalent. Requires the puzzle:write OAuth scope.",
+  ui: { visibility: ["app"] },
+  schema: z.object({
+    angle: z
+      .string()
+      .trim()
+      .min(1)
+      .describe("The theme/angle the batch was drawn from."),
+    solutions: z
+      .array(
+        z.object({
+          id: z.string().describe("Puzzle id."),
+          win: z.boolean().describe("Whether the puzzle was solved without errors."),
+          rated: z
+            .boolean()
+            .optional()
+            .default(true)
+            .describe("Whether this attempt should affect rating (default true)."),
+        }),
+      )
+      .min(1)
+      .describe("Per-puzzle results."),
+  }),
+  handler: async ({ angle, solutions }, { client }) => {
+    const body = {
+      solutions: solutions.map((s) => ({
+        id: s.id,
+        win: s.win,
+        rated: s.rated ?? true,
+      })),
+    };
+    const response = await client.postJson(
+      `/puzzle/batch/${encodeURIComponent(angle)}`,
+      body,
+    );
+    return (await response.json()) as object;
+  },
+});

--- a/src/tools/apps/view-pgn.ts
+++ b/src/tools/apps/view-pgn.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { Chess } from "chess.js";
+import { tool } from "../../registry.js";
+import type {
+  PgnHeaders,
+  PgnProps,
+  UiToolResult,
+} from "../../types/ui-props.js";
+
+const HEADER_RE = /^\[(\w+)\s+"([^"]*)"\]/;
+
+/**
+ * Extract a Lichess game id from a bare id, a path with a perspective suffix
+ * (`AxGa6qxX/black`), or a full URL (`https://lichess.org/AxGa6qxX/black`).
+ * Lichess game ids are 8 alphanumeric chars (short form) or 12 (full form).
+ */
+function normalizeGameId(input: string): string {
+  let s = input.trim();
+  s = s.replace(/^https?:\/\//i, "");
+  s = s.replace(/^(www\.)?lichess\.org\//i, "");
+  s = s.split(/[/?#]/, 1)[0];
+  if (!/^[A-Za-z0-9]{8}([A-Za-z0-9]{4})?$/.test(s)) {
+    throw new Error(
+      `"${input}" is not a Lichess game id or URL — expected the 8-character id (e.g. AxGa6qxX) or a full https://lichess.org/<id> URL`,
+    );
+  }
+  return s.slice(0, 8);
+}
+
+function extractHeaders(pgn: string): PgnHeaders {
+  const headers: PgnHeaders = {};
+  for (const line of pgn.split(/\r?\n/)) {
+    const m = HEADER_RE.exec(line.trim());
+    if (!m) {
+      if (line.trim().length === 0 && Object.keys(headers).length > 0) break;
+      continue;
+    }
+    const [, tag, value] = m;
+    switch (tag) {
+      case "White": headers.white = value; break;
+      case "Black": headers.black = value; break;
+      case "WhiteElo": headers.whiteElo = value; break;
+      case "BlackElo": headers.blackElo = value; break;
+      case "Event": headers.event = value; break;
+      case "Site": headers.site = value; break;
+      case "Date": headers.date = value; break;
+      case "Result": headers.result = value; break;
+      case "FEN": headers.fen = value; break;
+      case "SetUp": headers.setup = value; break;
+    }
+  }
+  return headers;
+}
+
+export const viewPgn = tool({
+  name: "view_pgn",
+  description:
+    "Open an interactive PGN viewer in Claude Desktop with a real chess board, prev/next/play controls, and clickable move list. Provide either gameId (Lichess game) or a raw PGN string.",
+  schema: z
+    .object({
+      gameId: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+          "Lichess game id (8 chars, e.g. AxGa6qxX). A full URL like https://lichess.org/AxGa6qxX/black is also accepted and normalized.",
+        ),
+      pgn: z.string().trim().min(1).optional().describe("Raw PGN to view."),
+    })
+    .refine((v) => Boolean(v.gameId || v.pgn), {
+      message: "Provide either gameId or pgn",
+    }),
+  ui: {
+    resourceUri: "ui://lichess-mcp/pgn.html",
+    htmlFile: "pgn.html",
+  },
+  handler: async ({ gameId, pgn }, { client }) => {
+    const id = gameId ? normalizeGameId(gameId) : null;
+    // /game/export/{id} lives at the site root, NOT under /api — sending it to
+    // /api/game/export/{id} returns 404. Override the base URL for this call.
+    const text =
+      pgn ??
+      (await client.pgn(`/game/export/${id}`, { baseUrl: "https://lichess.org" }));
+    // Probe-parse before sending props to the iframe — chess.js@1 throws on
+    // invalid PGN, and the iframe's loadPgn would otherwise reject module
+    // evaluation and leave a blank panel. Common cause: Lichess variant games
+    // (Crazyhouse, Atomic, Antichess, etc.) which chess.js can't parse.
+    try {
+      new Chess().loadPgn(text);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Could not parse PGN${id ? ` for ${id}` : ""}: ${reason}. ` +
+          `Only standard chess and Chess960 PGNs are supported.`,
+      );
+    }
+
+    const headers = extractHeaders(text);
+    const lichessUrl = id ? `https://lichess.org/${id}` : null;
+
+    const props: PgnProps = { pgn: text, headers, lichessUrl };
+
+    const lines: string[] = [];
+    if (headers.event) lines.push(headers.event);
+    if (headers.white || headers.black) {
+      const w = headers.white ?? "?";
+      const b = headers.black ?? "?";
+      const wElo = headers.whiteElo ? ` (${headers.whiteElo})` : "";
+      const bElo = headers.blackElo ? ` (${headers.blackElo})` : "";
+      lines.push(`${w}${wElo} vs ${b}${bElo}`);
+    }
+    if (headers.date) lines.push(headers.date);
+    if (headers.result) lines.push(`Result: ${headers.result}`);
+    if (lichessUrl) lines.push(lichessUrl);
+    lines.push("");
+    lines.push(text.length > 800 ? text.slice(0, 800) + "…" : text);
+
+    const result: UiToolResult<PgnProps> = {
+      __uiResult: true,
+      text: lines.join("\n"),
+      props,
+    };
+    return result;
+  },
+});

--- a/src/tools/games.ts
+++ b/src/tools/games.ts
@@ -35,8 +35,9 @@ function appendBooleanParams(
 async function pgnOrJsonToText(
   client: LichessClient,
   path: string,
+  options: { baseUrl?: string } = {},
 ): Promise<string> {
-  const result = await client.pgnOrJson(path);
+  const result = await client.pgnOrJson(path, options);
   return result.kind === "pgn" ? result.pgn : JSON.stringify(result.data, null, 2);
 }
 
@@ -59,7 +60,11 @@ const exportGame = tool({
   handler: async ({ gameId, ...flags }, { client }) => {
     const params = new URLSearchParams();
     appendBooleanParams(params, flags);
-    return pgnOrJsonToText(client, `/game/export/${gameId}?${params.toString()}`);
+    // /game/export/{id} lives at the site root, NOT under /api — calling
+    // /api/game/export/{id} returns 404.
+    return pgnOrJsonToText(client, `/game/export/${gameId}?${params.toString()}`, {
+      baseUrl: "https://lichess.org",
+    });
   },
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 import { AnyToolDefinition } from "../registry.js";
 import { accountTools } from "./account.js";
+import { appTools } from "./apps/index.js";
 import { analysisTools } from "./analysis.js";
 import { arenaTools } from "./arena.js";
 import { boardTools } from "./board.js";
@@ -47,4 +48,5 @@ export const allTools: AnyToolDefinition[] = [
   ...puzzlesTools,
   ...tvTools,
   ...analysisTools,
+  ...appTools,
 ];

--- a/src/tools/opening-explorer.ts
+++ b/src/tools/opening-explorer.ts
@@ -1,7 +1,58 @@
 import { z } from "zod";
 import { AnyToolDefinition, tool } from "../registry.js";
+import type { LichessClient } from "../http/client.js";
 
-const EXPLORER_BASE = "https://explorer.lichess.org";
+export const EXPLORER_BASE = "https://explorer.lichess.org";
+
+export interface MastersExplorerArgs {
+  fen?: string;
+  play?: string;
+  since?: string;
+  until?: string;
+  moves?: number;
+  topGames?: number;
+}
+
+export function fetchMastersExplorer<T = unknown>(
+  args: MastersExplorerArgs,
+  client: LichessClient,
+): Promise<T> {
+  const params = new URLSearchParams();
+  if (args.fen) params.set("fen", args.fen);
+  if (args.play) params.set("play", args.play);
+  if (args.since) params.set("since", args.since);
+  if (args.until) params.set("until", args.until);
+  if (args.moves !== undefined) params.set("moves", String(args.moves));
+  if (args.topGames !== undefined) params.set("topGames", String(args.topGames));
+  const qs = params.toString() ? `?${params.toString()}` : "";
+  return client.json<T>(`/masters${qs}`, { baseUrl: EXPLORER_BASE });
+}
+
+export interface LichessExplorerArgs {
+  variant?: string;
+  fen?: string;
+  play?: string;
+  speeds?: string;
+  ratings?: string;
+  since?: string;
+  until?: string;
+  moves?: number;
+  topGames?: number;
+  recentGames?: number;
+  history?: boolean;
+}
+
+export function fetchLichessExplorer<T = unknown>(
+  args: LichessExplorerArgs,
+  client: LichessClient,
+): Promise<T> {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(args)) {
+    if (value !== undefined) params.set(key, String(value));
+  }
+  const qs = params.toString() ? `?${params.toString()}` : "";
+  return client.json<T>(`/lichess${qs}`, { baseUrl: EXPLORER_BASE });
+}
 
 const getMastersOpenings = tool({
   name: "get_masters_openings",
@@ -14,17 +65,7 @@ const getMastersOpenings = tool({
     moves: z.number().int().min(1).optional().describe("Number of most-played moves to return"),
     topGames: z.number().int().min(0).optional().describe("Number of top games to return"),
   }),
-  handler: async ({ fen, play, since, until, moves, topGames }, { client }) => {
-    const params = new URLSearchParams();
-    if (fen) params.set("fen", fen);
-    if (play) params.set("play", play);
-    if (since) params.set("since", since);
-    if (until) params.set("until", until);
-    if (moves !== undefined) params.set("moves", String(moves));
-    if (topGames !== undefined) params.set("topGames", String(topGames));
-    const qs = params.toString() ? `?${params.toString()}` : "";
-    return client.json(`/masters${qs}`, { baseUrl: EXPLORER_BASE });
-  },
+  handler: async (args, { client }) => fetchMastersExplorer(args, client),
 });
 
 const getLichessOpenings = tool({
@@ -43,14 +84,7 @@ const getLichessOpenings = tool({
     recentGames: z.number().int().min(0).optional().describe("Number of recent games"),
     history: z.boolean().optional().describe("Include history data"),
   }),
-  handler: async (args, { client }) => {
-    const params = new URLSearchParams();
-    for (const [key, value] of Object.entries(args)) {
-      if (value !== undefined) params.set(key, String(value));
-    }
-    const qs = params.toString() ? `?${params.toString()}` : "";
-    return client.json(`/lichess${qs}`, { baseUrl: EXPLORER_BASE });
-  },
+  handler: async (args, { client }) => fetchLichessExplorer(args, client),
 });
 
 const getPlayerOpenings = tool({

--- a/src/tools/puzzles.ts
+++ b/src/tools/puzzles.ts
@@ -57,25 +57,43 @@ const getPuzzleBatch = tool({
 
 const solvePuzzleBatch = tool({
   name: "solve_puzzle_batch",
-  description: "Submit solved puzzles from a batch",
+  description:
+    "Submit solved puzzles from a batch back to Lichess. With `rated: true` (default) the result affects the user's puzzle rating. The response contains rounds[] with per-puzzle ratingDiff and the new glicko rating.",
   schema: z.object({
     angle: z.string().trim().min(1).describe("Puzzle theme/angle"),
     solutions: z
       .array(
         z.object({
           id: z.string().describe("Puzzle ID"),
-          win: z.boolean().describe("Whether the puzzle was solved correctly"),
-          time: z.number().int().describe("Time taken in milliseconds"),
+          win: z.boolean().describe("Whether the puzzle was solved without errors"),
+          rated: z
+            .boolean()
+            .optional()
+            .default(true)
+            .describe("Whether this attempt should affect the user's rating"),
         }),
       )
       .describe("Array of puzzle solutions"),
-    nb: z.number().int().min(1).max(500).optional().describe("Number of new puzzles to return"),
+    nb: z
+      .number()
+      .int()
+      .min(0)
+      .max(50)
+      .optional()
+      .describe("If > 0, response also includes a fresh batch of N puzzles"),
   }),
   handler: async ({ angle, solutions, nb }, { client }) => {
     const qs = nb !== undefined ? `?nb=${nb}` : "";
+    const body = {
+      solutions: solutions.map((s) => ({
+        id: s.id,
+        win: s.win,
+        rated: s.rated ?? true,
+      })),
+    };
     const response = await client.postJson(
       `/puzzle/batch/${encodeURIComponent(angle)}${qs}`,
-      { solutions },
+      body,
     );
     return (await response.json()) as object;
   },

--- a/src/types/ui-props.ts
+++ b/src/types/ui-props.ts
@@ -1,0 +1,122 @@
+/**
+ * Shape of `_meta["modelcontextprotocol.io/ui"].props` we ship from each app
+ * tool result. Imported by both server-side handlers and iframe `main.ts`
+ * files (via tsconfig.ui.json) so the contract is enforced on both ends.
+ */
+
+export type Color = "white" | "black";
+
+export interface PuzzlePgnGame {
+  /** Lichess game id (8 chars). */
+  id?: string;
+  /** Full game PGN played up to (and including) the puzzle's setup move. */
+  pgn: string;
+}
+
+export interface PuzzleSpec {
+  puzzleId: string;
+  /** FEN of the position the user faces (after the opponent's setup move). */
+  fen: string;
+  /** Solution moves in UCI form (alternating user / opponent). */
+  solution: string[];
+  /** Side the user plays. */
+  orientation: Color;
+  themes: string[];
+  rating: number | null;
+  lichessUrl: string;
+}
+
+export interface PuzzleSession {
+  /** Theme/angle for the batch (e.g. "mix", "endgame"). Empty for single mode. */
+  angle: string;
+  /** When true, completing the batch submits results to update Lichess rating. */
+  rated: boolean;
+}
+
+export interface PuzzleProps {
+  /** Puzzle queue. Length 1 in single mode, N in rated batch mode. */
+  puzzles: PuzzleSpec[];
+  session: PuzzleSession;
+}
+
+export interface PuzzleRound {
+  id: string;
+  win: boolean;
+  ratingDiff: number;
+}
+
+export interface PuzzleSubmitResult {
+  rounds: PuzzleRound[];
+  glicko: { rating: number; deviation: number } | null;
+}
+
+export interface PgnHeaders {
+  white?: string;
+  black?: string;
+  whiteElo?: string;
+  blackElo?: string;
+  event?: string;
+  site?: string;
+  date?: string;
+  result?: string;
+  fen?: string;
+  setup?: string;
+}
+
+export interface PgnProps {
+  pgn: string;
+  headers: PgnHeaders;
+  lichessUrl: string | null;
+}
+
+export interface ExplorerMove {
+  uci: string;
+  san: string;
+  white: number;
+  draws: number;
+  black: number;
+  averageRating?: number;
+  averageOpponentRating?: number;
+}
+
+export interface ExplorerGame {
+  id?: string;
+  uci?: string;
+  winner?: "white" | "black" | null;
+  white: { name?: string; rating?: number };
+  black: { name?: string; rating?: number };
+  year?: number;
+  month?: string;
+}
+
+export interface ExplorerData {
+  white: number;
+  draws: number;
+  black: number;
+  moves: ExplorerMove[];
+  topGames?: ExplorerGame[];
+  recentGames?: ExplorerGame[];
+  opening?: { eco?: string; name?: string } | null;
+}
+
+export type ExplorerSource = "masters" | "lichess";
+
+export interface OpeningsProps {
+  /** FEN the play history is rooted at. */
+  rootFen: string;
+  /** Comma-separated UCI moves played from rootFen. May be empty. */
+  play: string;
+  /** Current position FEN (rootFen with `play` applied). */
+  currentFen: string;
+  source: ExplorerSource;
+  initialData: ExplorerData;
+}
+
+/** Discriminator returned by app-tool handlers (consumed by server.ts). */
+export interface UiToolResult<P> {
+  __uiResult: true;
+  text: string;
+  props: P;
+}
+
+export const UI_META_KEY = "modelcontextprotocol.io/ui";

--- a/src/ui-loader.ts
+++ b/src/ui-loader.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Resolves a Vite-bundled iframe HTML file (`build/ui/<htmlFile>`) sitting
+ * next to the compiled server entry. Cached at boot — the file is small but
+ * the resource handler can fire on every tool invocation.
+ */
+const cache = new Map<string, string>();
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export function readUiHtml(htmlFile: string): string {
+  let html = cache.get(htmlFile);
+  if (html === undefined) {
+    html = readFileSync(resolve(here, "ui", htmlFile), "utf-8");
+    cache.set(htmlFile, html);
+  }
+  return html;
+}

--- a/src/ui/openings/index.html
+++ b/src/ui/openings/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Opening Explorer</title>
+  </head>
+  <body>
+    <div id="app">
+      <div class="board-wrap"><div id="board"></div></div>
+      <div class="panel">
+        <h3 id="title">Opening Explorer</h3>
+        <div class="meta" id="meta"></div>
+        <div class="controls">
+          <button id="back">◀ Back</button>
+          <button id="reset">Reset</button>
+          <button id="flip">Flip</button>
+          <button id="source">Switch to Lichess</button>
+        </div>
+        <div class="status" id="status"></div>
+        <ul class="move-list" id="moves"></ul>
+        <h3 style="margin-top:8px">Top games</h3>
+        <ul class="move-list" id="games"></ul>
+      </div>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/ui/openings/main.ts
+++ b/src/ui/openings/main.ts
@@ -1,0 +1,274 @@
+import "../shared/theme.css";
+import { Chess } from "chess.js";
+import { bootstrap, extractUiProps } from "../shared/app-bootstrap.js";
+import {
+  applyUci,
+  legalDestsFor,
+  makeBoard,
+  toUci,
+  turnColor,
+} from "../shared/board.js";
+import type { Color, Key } from "../shared/board.js";
+import type {
+  ExplorerData,
+  ExplorerMove,
+  ExplorerSource,
+  OpeningsProps,
+} from "../../types/ui-props.js";
+
+const root = document.getElementById("board")!;
+const titleEl = document.getElementById("title")!;
+const metaEl = document.getElementById("meta")!;
+const statusEl = document.getElementById("status")!;
+const movesEl = document.getElementById("moves") as HTMLUListElement;
+const gamesEl = document.getElementById("games") as HTMLUListElement;
+const backBtn = document.getElementById("back") as HTMLButtonElement;
+const resetBtn = document.getElementById("reset") as HTMLButtonElement;
+const flipBtn = document.getElementById("flip") as HTMLButtonElement;
+const sourceBtn = document.getElementById("source") as HTMLButtonElement;
+
+const handle = await bootstrap<OpeningsProps>("lichess-openings");
+const board = makeBoard(root);
+
+interface State {
+  rootFen: string;
+  play: string[];
+  currentFen: string;
+  source: ExplorerSource;
+  data: ExplorerData;
+  orientation: Color;
+}
+
+const state: State = {
+  rootFen: handle.props.rootFen,
+  play: handle.props.play ? handle.props.play.split(",") : [],
+  currentFen: handle.props.currentFen,
+  source: handle.props.source,
+  data: handle.props.initialData,
+  orientation: "white",
+};
+
+function renderBoard() {
+  const turn = turnColor(state.currentFen);
+  const last = state.play.at(-1);
+  const lastMove = last
+    ? ([last.slice(0, 2) as Key, last.slice(2, 4) as Key] as [Key, Key])
+    : undefined;
+  board.set({
+    fen: state.currentFen,
+    orientation: state.orientation,
+    turnColor: turn,
+    lastMove,
+    movable: {
+      free: false,
+      color: turn,
+      dests: legalDestsFor(state.currentFen),
+      events: { after: onUserMove },
+    },
+  });
+}
+
+function renderMoves() {
+  movesEl.innerHTML = "";
+  const total = state.data.white + state.data.draws + state.data.black;
+  for (const m of state.data.moves ?? []) {
+    const games = m.white + m.draws + m.black;
+    const li = document.createElement("li");
+    const left = document.createElement("span");
+    left.textContent = m.san;
+    const right = document.createElement("span");
+    right.style.display = "flex";
+    right.style.alignItems = "center";
+    right.style.gap = "8px";
+    const count = document.createElement("span");
+    count.style.color = "var(--muted)";
+    count.style.fontSize = "12px";
+    count.textContent = total
+      ? `${games.toLocaleString()} (${Math.round((games / total) * 100)}%)`
+      : `${games.toLocaleString()}`;
+    const bar = makeBar(m);
+    right.append(count, bar);
+    li.append(left, right);
+    li.addEventListener("click", () => playMove(m.uci));
+    movesEl.appendChild(li);
+  }
+  if (!state.data.moves || state.data.moves.length === 0) {
+    const li = document.createElement("li");
+    li.textContent = "No games for this position.";
+    li.style.cursor = "default";
+    movesEl.appendChild(li);
+  }
+}
+
+function makeBar(m: ExplorerMove): HTMLElement {
+  const t = m.white + m.draws + m.black || 1;
+  const bar = document.createElement("span");
+  bar.className = "bar";
+  const w = document.createElement("span");
+  w.className = "w";
+  w.style.flexBasis = `${(m.white / t) * 100}%`;
+  const d = document.createElement("span");
+  d.className = "d";
+  d.style.flexBasis = `${(m.draws / t) * 100}%`;
+  const b = document.createElement("span");
+  b.className = "b";
+  b.style.flexBasis = `${(m.black / t) * 100}%`;
+  bar.append(w, d, b);
+  return bar;
+}
+
+function renderGames() {
+  gamesEl.innerHTML = "";
+  const games = state.data.topGames ?? state.data.recentGames ?? [];
+  for (const g of games.slice(0, 6)) {
+    const li = document.createElement("li");
+    const w = g.white?.name ?? "?";
+    const wr = g.white?.rating ? ` (${g.white.rating})` : "";
+    const b = g.black?.name ?? "?";
+    const br = g.black?.rating ? ` (${g.black.rating})` : "";
+    const left = document.createElement("span");
+    left.textContent = `${w}${wr} vs ${b}${br}`;
+    const right = document.createElement("span");
+    right.style.color = "var(--muted)";
+    right.style.fontSize = "12px";
+    const winnerSymbol =
+      g.winner === "white" ? "1-0" : g.winner === "black" ? "0-1" : "½-½";
+    right.textContent = `${winnerSymbol}${g.year ? " · " + g.year : ""}`;
+    li.append(left, right);
+    if (g.id) {
+      li.style.cursor = "pointer";
+      const url = `https://lichess.org/${g.id}`;
+      li.title = url;
+      li.addEventListener("click", () => {
+        void handle.app.openLink({ url });
+      });
+    } else {
+      li.style.cursor = "default";
+    }
+    gamesEl.appendChild(li);
+  }
+}
+
+function renderMeta() {
+  const total = state.data.white + state.data.draws + state.data.black;
+  const parts: string[] = [];
+  if (state.data.opening?.name) parts.push(state.data.opening.name);
+  parts.push(state.source === "masters" ? "Masters" : "Lichess");
+  parts.push(`${total.toLocaleString()} games`);
+  metaEl.textContent = parts.join(" · ");
+  sourceBtn.textContent =
+    state.source === "masters" ? "Switch to Lichess" : "Switch to Masters";
+  backBtn.disabled = state.play.length === 0;
+  resetBtn.disabled = state.play.length === 0;
+}
+
+function loadProps(p: OpeningsProps) {
+  state.rootFen = p.rootFen;
+  state.play = p.play ? p.play.split(",") : [];
+  state.currentFen = p.currentFen;
+  state.source = p.source;
+  state.data = p.initialData;
+  setStatus("");
+  renderBoard();
+  renderMoves();
+  renderGames();
+  renderMeta();
+}
+
+function setStatus(msg: string, kind: "" | "ok" | "err" = "") {
+  statusEl.textContent = msg;
+  statusEl.className = `status${kind ? " " + kind : ""}`;
+  if (!msg) statusEl.style.minHeight = "0";
+  else statusEl.style.minHeight = "";
+}
+
+async function fetchExplorer(playArr: string[], source: ExplorerSource) {
+  setStatus("Loading…");
+  try {
+    const result = await handle.app.callServerTool({
+      name: "explore_openings",
+      arguments: {
+        fen: state.rootFen,
+        play: playArr.join(","),
+        source,
+      },
+    });
+    if (result.isError) {
+      const text = result.content?.[0]?.type === "text" ? result.content[0].text : "Server error";
+      throw new Error(text);
+    }
+    const props = extractUiProps<OpeningsProps>(result);
+    if (props) loadProps(props);
+    else setStatus("Server returned no explorer data.", "err");
+  } catch (err) {
+    setStatus(`Failed to load: ${(err as Error).message}`, "err");
+  }
+}
+
+function playMove(uci: string) {
+  const next = applyUci(state.currentFen, uci);
+  if (!next) {
+    setStatus("Illegal move.", "err");
+    return;
+  }
+  // Optimistically update board; the server response will refresh data.
+  state.currentFen = next;
+  state.play = [...state.play, uci];
+  renderBoard();
+  void fetchExplorer(state.play, state.source);
+}
+
+function onUserMove(orig: Key, dest: Key) {
+  // Auto-promote to queen for explorer; the move is just navigation.
+  const promo = needsPromotion(state.currentFen, orig, dest) ? "q" : undefined;
+  playMove(toUci(orig, dest, promo));
+}
+
+function needsPromotion(fen: string, orig: Key, dest: Key): boolean {
+  if (orig === "a0") return false;
+  const chess = new Chess(fen);
+  const piece = chess.get(orig);
+  if (!piece || piece.type !== "p") return false;
+  const destRank = parseInt(dest[1], 10);
+  return destRank === 1 || destRank === 8;
+}
+
+backBtn.addEventListener("click", () => {
+  if (state.play.length === 0) return;
+  state.play = state.play.slice(0, -1);
+  state.currentFen = applyAll(state.rootFen, state.play);
+  renderBoard();
+  void fetchExplorer(state.play, state.source);
+});
+
+resetBtn.addEventListener("click", () => {
+  state.play = [];
+  state.currentFen = state.rootFen;
+  renderBoard();
+  void fetchExplorer([], state.source);
+});
+
+flipBtn.addEventListener("click", () => {
+  state.orientation = state.orientation === "white" ? "black" : "white";
+  renderBoard();
+});
+
+sourceBtn.addEventListener("click", () => {
+  const next = state.source === "masters" ? "lichess" : "masters";
+  state.source = next;
+  void fetchExplorer(state.play, next);
+});
+
+function applyAll(rootFen: string, play: string[]): string {
+  let fen = rootFen;
+  for (const uci of play) {
+    const next = applyUci(fen, uci);
+    if (!next) return fen;
+    fen = next;
+  }
+  return fen;
+}
+
+titleEl.textContent = "Opening Explorer";
+handle.onUpdate(loadProps);
+loadProps(handle.props);

--- a/src/ui/pgn/index.html
+++ b/src/ui/pgn/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PGN Viewer</title>
+  </head>
+  <body>
+    <div id="app">
+      <div class="board-wrap"><div id="board"></div></div>
+      <div class="panel">
+        <h3 id="title">Game</h3>
+        <div class="meta" id="meta"></div>
+        <div class="controls">
+          <button id="first">⏮</button>
+          <button id="prev">◀</button>
+          <button id="play" class="primary">▶</button>
+          <button id="next">▶</button>
+          <button id="last">⏭</button>
+          <button id="flip">Flip</button>
+        </div>
+        <ol class="move-list pgn-move-list" id="moves"></ol>
+        <div class="meta"><a id="lichess-link" href="#" target="_blank" rel="noopener" style="display:none">View on lichess.org</a></div>
+      </div>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/ui/pgn/main.ts
+++ b/src/ui/pgn/main.ts
@@ -1,0 +1,231 @@
+import "../shared/theme.css";
+import { Chess } from "chess.js";
+import { bootstrap } from "../shared/app-bootstrap.js";
+import { makeBoard } from "../shared/board.js";
+import type { Color, Key } from "../shared/board.js";
+import type { PgnProps } from "../../types/ui-props.js";
+
+interface MoveStep {
+  san: string;
+  from: Key;
+  to: Key;
+  fen: string;
+  color: Color;
+  moveNumber: number;
+}
+
+const root = document.getElementById("board")!;
+const titleEl = document.getElementById("title")!;
+const metaEl = document.getElementById("meta")!;
+const movesEl = document.getElementById("moves") as HTMLOListElement;
+const linkEl = document.getElementById("lichess-link") as HTMLAnchorElement;
+const firstBtn = document.getElementById("first") as HTMLButtonElement;
+const prevBtn = document.getElementById("prev") as HTMLButtonElement;
+const playBtn = document.getElementById("play") as HTMLButtonElement;
+const nextBtn = document.getElementById("next") as HTMLButtonElement;
+const lastBtn = document.getElementById("last") as HTMLButtonElement;
+const flipBtn = document.getElementById("flip") as HTMLButtonElement;
+
+function showError(message: string) {
+  titleEl.textContent = "Could not load PGN";
+  metaEl.textContent = message;
+  movesEl.innerHTML = "";
+  linkEl.style.display = "none";
+}
+
+let handle: Awaited<ReturnType<typeof bootstrap<PgnProps>>>;
+try {
+  handle = await bootstrap<PgnProps>("lichess-pgn");
+} catch (err) {
+  showError(err instanceof Error ? err.message : String(err));
+  throw err;
+}
+const board = makeBoard(root, { viewOnly: true });
+
+let steps: MoveStep[] = [];
+let startFen = "";
+let ply = 0;
+let orientation: Color = "white";
+let playing = false;
+let timer: number | undefined;
+
+function loadProps(p: PgnProps) {
+  try {
+    const chess = new Chess();
+    chess.loadPgn(p.pgn);
+    const history = chess.history({ verbose: true }) as Array<{
+      from: Key;
+      to: Key;
+      san: string;
+      color: "w" | "b";
+      promotion?: string;
+    }>;
+    // Replay to capture FEN after each move. Seed from the PGN's [FEN] header so
+    // setup-position games (chess960, studies, problems) replay from the right start.
+    const replay = p.headers.fen ? new Chess(p.headers.fen) : new Chess();
+    startFen = replay.fen();
+    steps = history.map((m) => {
+      const moveNumber = Number(replay.fen().split(" ")[5] ?? "1");
+      replay.move({ from: m.from, to: m.to, promotion: m.promotion });
+      return {
+        san: m.san,
+        from: m.from,
+        to: m.to,
+        fen: replay.fen(),
+        color: m.color === "w" ? "white" : "black",
+        moveNumber,
+      };
+    });
+
+    ply = 0;
+    orientation = "white";
+
+    titleEl.textContent = p.headers.event || "Game";
+    const metaParts: string[] = [];
+    const w = p.headers.white ?? "";
+    const b = p.headers.black ?? "";
+    if (w || b) {
+      const wElo = p.headers.whiteElo ? ` (${p.headers.whiteElo})` : "";
+      const bElo = p.headers.blackElo ? ` (${p.headers.blackElo})` : "";
+      metaParts.push(`${w || "?"}${wElo} vs ${b || "?"}${bElo}`);
+    }
+    if (p.headers.date) metaParts.push(p.headers.date);
+    if (p.headers.result) metaParts.push(p.headers.result);
+    metaEl.textContent = metaParts.join(" · ");
+
+    if (p.lichessUrl) {
+      linkEl.href = p.lichessUrl;
+      linkEl.style.display = "";
+    } else {
+      linkEl.style.display = "none";
+    }
+
+    renderMoves();
+    applyBoard();
+  } catch (err) {
+    showError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+function applyBoard() {
+  const fen = ply === 0 ? startFen : steps[ply - 1].fen;
+  const lastMove = ply === 0 ? undefined : [steps[ply - 1].from, steps[ply - 1].to] as [Key, Key];
+  board.set({ fen, orientation, lastMove });
+  updateMoveHighlight();
+  prevBtn.disabled = ply === 0;
+  firstBtn.disabled = ply === 0;
+  nextBtn.disabled = ply >= steps.length;
+  lastBtn.disabled = ply >= steps.length;
+}
+
+function renderMoves() {
+  movesEl.innerHTML = "";
+  for (let i = 0; i < steps.length;) {
+    const moveNum = steps[i].moveNumber;
+    const whiteIdx = steps[i].color === "white" ? i : -1;
+    const blackIdx =
+      whiteIdx === -1
+        ? i
+        : steps[i + 1]?.color === "black" && steps[i + 1]?.moveNumber === moveNum
+          ? i + 1
+          : -1;
+
+    const li = document.createElement("li");
+    li.className = "pgn-move-row";
+
+    const num = document.createElement("span");
+    num.className = "pgn-move-number";
+    num.textContent = `${moveNum}.`;
+
+    li.append(num, makeMoveCell(whiteIdx, "white"), makeMoveCell(blackIdx, "black"));
+    movesEl.appendChild(li);
+
+    i = blackIdx > whiteIdx ? blackIdx + 1 : i + 1;
+  }
+}
+
+function updateMoveHighlight() {
+  const items = movesEl.querySelectorAll<HTMLElement>("[data-ply]");
+  items.forEach((item) => item.classList.remove("current"));
+  if (ply > 0) {
+    const current = movesEl.querySelector<HTMLElement>(`[data-ply="${ply}"]`);
+    current?.classList.add("current");
+    current?.scrollIntoView({ block: "nearest" });
+  }
+}
+
+function makeMoveCell(idx: number, side: Color): HTMLElement {
+  if (idx < 0) {
+    const empty = document.createElement("span");
+    empty.className = "pgn-move pgn-move-placeholder";
+    empty.setAttribute("aria-hidden", "true");
+    return empty;
+  }
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "pgn-move";
+  button.textContent = steps[idx].san;
+  button.dataset.ply = String(idx + 1);
+  button.setAttribute(
+    "aria-label",
+    `Go to ${steps[idx].moveNumber}${side === "white" ? "." : "..."} ${steps[idx].san}`,
+  );
+  button.addEventListener("click", () => {
+    ply = idx + 1;
+    stopPlaying();
+    applyBoard();
+  });
+  return button;
+}
+
+function stopPlaying() {
+  playing = false;
+  if (timer !== undefined) {
+    clearInterval(timer);
+    timer = undefined;
+  }
+  playBtn.textContent = "▶";
+}
+
+function startPlaying() {
+  if (ply >= steps.length) {
+    ply = 0;
+    applyBoard();
+  }
+  playing = true;
+  playBtn.textContent = "⏸";
+  timer = window.setInterval(() => {
+    if (ply >= steps.length) {
+      stopPlaying();
+      return;
+    }
+    ply += 1;
+    applyBoard();
+  }, 1500);
+}
+
+firstBtn.addEventListener("click", () => { stopPlaying(); ply = 0; applyBoard(); });
+prevBtn.addEventListener("click", () => { stopPlaying(); if (ply > 0) ply -= 1; applyBoard(); });
+nextBtn.addEventListener("click", () => { stopPlaying(); if (ply < steps.length) ply += 1; applyBoard(); });
+lastBtn.addEventListener("click", () => { stopPlaying(); ply = steps.length; applyBoard(); });
+playBtn.addEventListener("click", () => { playing ? stopPlaying() : startPlaying(); });
+flipBtn.addEventListener("click", () => {
+  orientation = orientation === "white" ? "black" : "white";
+  applyBoard();
+});
+
+linkEl.addEventListener("click", (e) => {
+  e.preventDefault();
+  const url = linkEl.href;
+  if (url && url !== "#") void handle.app.openLink({ url });
+});
+
+document.addEventListener("keydown", (e) => {
+  if (e.key === "ArrowLeft") prevBtn.click();
+  else if (e.key === "ArrowRight") nextBtn.click();
+  else if (e.key === " ") { e.preventDefault(); playBtn.click(); }
+});
+
+handle.onUpdate(loadProps);
+loadProps(handle.props);

--- a/src/ui/puzzle/index.html
+++ b/src/ui/puzzle/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lichess Puzzle</title>
+  </head>
+  <body>
+    <div id="app">
+      <div class="board-wrap"><div id="board"></div></div>
+      <div class="panel">
+        <h3 id="title">Puzzle</h3>
+        <div class="meta" id="progress"></div>
+        <div class="meta" id="meta"></div>
+        <div class="status" id="status">Your move.</div>
+        <div class="controls" id="controls">
+          <button id="hint">Hint</button>
+          <button id="flip">Flip</button>
+          <button id="next" class="primary">Next puzzle</button>
+        </div>
+        <div id="results" style="display:none"></div>
+        <div class="meta">
+          <a id="lichess-link" href="#" target="_blank" rel="noopener">View on lichess.org</a>
+        </div>
+      </div>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/ui/puzzle/main.ts
+++ b/src/ui/puzzle/main.ts
@@ -1,0 +1,493 @@
+import "../shared/theme.css";
+import { bootstrap, extractUiProps } from "../shared/app-bootstrap.js";
+import {
+  applyUci,
+  legalDestsFor,
+  makeBoard,
+  toUci,
+  turnColor,
+} from "../shared/board.js";
+import type { Color, Key } from "../shared/board.js";
+import type {
+  PuzzleProps,
+  PuzzleSpec,
+  PuzzleSubmitResult,
+} from "../../types/ui-props.js";
+
+interface Attempt {
+  id: string;
+  win: boolean;
+}
+
+interface IframeState {
+  // Session
+  session: { angle: string; rated: boolean };
+  queue: PuzzleSpec[];
+  index: number;
+  attempts: Attempt[];
+
+  // Per-puzzle live state
+  fen: string;
+  ply: number;
+  mistakeMade: boolean;
+  solved: boolean;
+  viewOrientation: Color;
+  done: boolean;
+}
+
+const root = document.getElementById("board")!;
+const titleEl = document.getElementById("title")!;
+const progressEl = document.getElementById("progress")!;
+const metaEl = document.getElementById("meta")!;
+const statusEl = document.getElementById("status")!;
+const controlsEl = document.getElementById("controls")!;
+const resultsEl = document.getElementById("results") as HTMLDivElement;
+const hintBtn = document.getElementById("hint") as HTMLButtonElement;
+const flipBtn = document.getElementById("flip") as HTMLButtonElement;
+const nextBtn = document.getElementById("next") as HTMLButtonElement;
+const linkEl = document.getElementById("lichess-link") as HTMLAnchorElement;
+
+const handle = await bootstrap<PuzzleProps>("lichess-puzzle");
+const board = makeBoard(root);
+
+const state: IframeState = {
+  session: handle.props.session,
+  queue: handle.props.puzzles,
+  index: 0,
+  attempts: [],
+  fen: "",
+  ply: 0,
+  mistakeMade: false,
+  solved: false,
+  viewOrientation: "white",
+  done: false,
+};
+
+function current(): PuzzleSpec | undefined {
+  return state.queue[state.index];
+}
+
+function setStatus(message: string, kind: "" | "ok" | "err" = "") {
+  statusEl.textContent = message;
+  statusEl.className = `status${kind ? " " + kind : ""}`;
+}
+
+function applyState() {
+  const spec = current();
+  if (!spec) return;
+  const userColor = spec.orientation;
+  const turn = turnColor(state.fen);
+  const isUserTurn = !state.solved && turn === userColor;
+
+  board.set({
+    fen: state.fen,
+    orientation: state.viewOrientation,
+    turnColor: turn,
+    movable: {
+      free: false,
+      color: isUserTurn ? userColor : undefined,
+      dests: isUserTurn ? legalDestsFor(state.fen) : new Map(),
+      events: { after: onMove },
+    },
+    lastMove: undefined,
+  });
+}
+
+function loadCurrent() {
+  const spec = current();
+  if (!spec) return;
+  state.fen = spec.fen;
+  state.ply = 0;
+  state.mistakeMade = false;
+  state.solved = false;
+  state.viewOrientation = spec.orientation;
+
+  titleEl.textContent = `Puzzle ${spec.puzzleId}`;
+  const meta: string[] = [];
+  if (spec.rating) meta.push(`rating ${spec.rating}`);
+  meta.push(spec.orientation === "white" ? "white to play" : "black to play");
+  if (spec.themes.length) meta.push(spec.themes.slice(0, 3).join(" · "));
+  metaEl.textContent = meta.join(" · ");
+  linkEl.href = spec.lichessUrl;
+  linkEl.style.display = "";
+
+  renderProgress();
+  setStatus("Your move.");
+  hintBtn.disabled = spec.solution.length === 0;
+  flipBtn.disabled = false;
+  applyState();
+}
+
+function renderProgress() {
+  if (state.queue.length <= 1) {
+    progressEl.textContent = state.session.rated ? "Rated session" : "";
+    return;
+  }
+  const total = state.queue.length;
+  const rated = state.session.rated ? "rated · " : "";
+  progressEl.textContent = `${rated}puzzle ${state.index + 1} of ${total}`;
+}
+
+function loadProps(p: PuzzleProps) {
+  state.session = p.session;
+  state.queue = p.puzzles;
+  state.index = 0;
+  state.attempts = [];
+  state.done = false;
+  resultsEl.style.display = "none";
+  resultsEl.innerHTML = "";
+  controlsEl.style.display = "";
+  nextBtn.disabled = false;
+  if (state.queue.length === 0) {
+    setStatus("No puzzles in this batch.", "err");
+    titleEl.textContent = "No puzzles";
+    metaEl.textContent = "";
+    progressEl.textContent = "";
+    nextBtn.disabled = true;
+    hintBtn.disabled = true;
+    flipBtn.disabled = true;
+    return;
+  }
+  updateNextLabel();
+  loadCurrent();
+}
+
+function updateNextLabel() {
+  const isLast = state.index >= state.queue.length - 1;
+  if (isLast && state.session.rated) {
+    nextBtn.textContent = "Submit & view results";
+    return;
+  }
+  if (state.queue.length <= 1) {
+    nextBtn.textContent = "Next puzzle";
+    return;
+  }
+  if (isLast) {
+    nextBtn.textContent = "Finish";
+  } else {
+    nextBtn.textContent = "Next puzzle";
+  }
+}
+
+async function onMove(orig: Key, dest: Key) {
+  const spec = current();
+  if (!spec || state.solved) return;
+  const expected = spec.solution[state.ply];
+  if (!expected) return;
+
+  const isPromotion = needsPromotion(state.fen, orig, dest);
+  let promotion: string | undefined;
+  if (isPromotion) {
+    const pawnColor = turnColor(state.fen);
+    const choice = await pickPromotion(pawnColor, dest);
+    if (!choice) {
+      applyState();
+      return;
+    }
+    promotion = choice;
+  }
+  const uci = toUci(orig, dest, promotion);
+
+  if (uci !== expected) {
+    state.mistakeMade = true;
+    setStatus("Not the move. Try again.", "err");
+    applyState();
+    return;
+  }
+
+  const afterUser = applyUci(state.fen, expected);
+  if (!afterUser) {
+    setStatus("Move could not be applied.", "err");
+    applyState();
+    return;
+  }
+  state.fen = afterUser;
+  state.ply += 1;
+  setStatus("Correct!", "ok");
+  applyState();
+
+  const reply = spec.solution[state.ply];
+  if (!reply) {
+    finishCurrent();
+    return;
+  }
+  await sleep(350);
+  const afterReply = applyUci(state.fen, reply);
+  if (!afterReply) {
+    setStatus("Move could not be applied.", "err");
+    return;
+  }
+  state.fen = afterReply;
+  state.ply += 1;
+
+  if (state.ply >= spec.solution.length) {
+    finishCurrent();
+  } else {
+    setStatus("Your move.");
+  }
+  applyState();
+}
+
+function finishCurrent() {
+  const spec = current();
+  if (!spec) return;
+  state.solved = true;
+  const win = !state.mistakeMade;
+  state.attempts.push({ id: spec.puzzleId, win });
+  setStatus(win ? "Solved! ✓" : "Solved with mistakes.", win ? "ok" : "err");
+  updateNextLabel();
+}
+
+function pickPromotion(pawnColor: Color, dest: Key): Promise<string | null> {
+  return new Promise((resolve) => {
+    const wrap = root.parentElement!;
+    const overlay = document.createElement("div");
+    overlay.className = "promo-overlay";
+
+    const fileIdx = dest.charCodeAt(0) - "a".charCodeAt(0);
+    const rankIdx = parseInt(dest[1], 10) - 1;
+    const orient = state.viewOrientation;
+    const xPct = (orient === "white" ? fileIdx : 7 - fileIdx) * 12.5;
+    const yPctTop = (orient === "white" ? 7 - rankIdx : rankIdx) * 12.5;
+    const direction = yPctTop === 0 ? 1 : -1;
+
+    const pieces: { letter: string; symbol: string; name: string }[] = [
+      { letter: "q", symbol: pawnColor === "white" ? "♕" : "♛", name: "Queen" },
+      { letter: "r", symbol: pawnColor === "white" ? "♖" : "♜", name: "Rook" },
+      { letter: "b", symbol: pawnColor === "white" ? "♗" : "♝", name: "Bishop" },
+      { letter: "n", symbol: pawnColor === "white" ? "♘" : "♞", name: "Knight" },
+    ];
+
+    function done(value: string | null) {
+      overlay.remove();
+      document.removeEventListener("keydown", onKey);
+      resolve(value);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") done(null);
+    }
+
+    pieces.forEach((p, i) => {
+      const btn = document.createElement("button");
+      btn.className = "promo-piece";
+      btn.type = "button";
+      btn.title = p.name;
+      btn.textContent = p.symbol;
+      btn.style.left = `${xPct}%`;
+      btn.style.top = `${yPctTop + direction * i * 12.5}%`;
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        done(p.letter);
+      });
+      overlay.appendChild(btn);
+    });
+
+    overlay.addEventListener("click", () => done(null));
+    document.addEventListener("keydown", onKey);
+    wrap.appendChild(overlay);
+  });
+}
+
+function needsPromotion(fen: string, orig: Key, dest: Key): boolean {
+  const ranks = fen.split(" ")[0].split("/");
+  const fileIdx = orig.charCodeAt(0) - "a".charCodeAt(0);
+  const rankIdx = 8 - parseInt(orig[1], 10);
+  const row = ranks[rankIdx];
+  let i = 0;
+  let col = 0;
+  while (i < row.length && col <= fileIdx) {
+    const ch = row[i];
+    if (/[1-8]/.test(ch)) {
+      col += parseInt(ch, 10);
+    } else {
+      if (col === fileIdx) {
+        if (ch.toLowerCase() !== "p") return false;
+        const destRank = parseInt(dest[1], 10);
+        return destRank === 1 || destRank === 8;
+      }
+      col += 1;
+    }
+    i += 1;
+  }
+  return false;
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+hintBtn.addEventListener("click", () => {
+  const spec = current();
+  if (!spec) return;
+  const next = spec.solution[state.ply];
+  if (!next) return;
+  setStatus(`Hint: try ${next.slice(0, 2)} → ${next.slice(2, 4)}`);
+});
+
+flipBtn.addEventListener("click", () => {
+  state.viewOrientation = state.viewOrientation === "white" ? "black" : "white";
+  applyState();
+});
+
+nextBtn.addEventListener("click", async () => {
+  // If the user has not finished the current puzzle yet, skip is treated as
+  // a loss so the rated submit is honest.
+  if (!state.solved) {
+    const spec = current();
+    if (spec) state.attempts.push({ id: spec.puzzleId, win: false });
+  }
+
+  // Unrated single-puzzle mode (daily / next / by-id): auto-fetch a fresh
+  // puzzle. Rated nb=1 sessions fall through to the batch-submit path below.
+  if (!state.session.rated && state.queue.length === 1) {
+    nextBtn.disabled = true;
+    setStatus("Loading next puzzle…");
+    try {
+      const result = await handle.app.callServerTool({
+        name: "play_puzzle",
+        arguments: { next: true },
+      });
+      if (result.isError) throw new Error(toolErrText(result));
+      const props = extractUiProps<PuzzleProps>(result);
+      if (props) loadProps(props);
+      else {
+        setStatus("Server returned no puzzle props.", "err");
+        nextBtn.disabled = false;
+      }
+    } catch (err) {
+      setStatus(`Failed to load next puzzle: ${(err as Error).message}`, "err");
+      nextBtn.disabled = false;
+    }
+    return;
+  }
+
+  // Batch mode.
+  if (state.index < state.queue.length - 1) {
+    state.index += 1;
+    updateNextLabel();
+    loadCurrent();
+    return;
+  }
+
+  // Last puzzle: submit (rated) or just show "done" (unrated batch).
+  if (state.session.rated) {
+    await submitBatch();
+  } else {
+    showUnratedDone();
+  }
+});
+
+linkEl.addEventListener("click", (e) => {
+  e.preventDefault();
+  const url = current()?.lichessUrl ?? linkEl.href;
+  if (url && url !== "#") void handle.app.openLink({ url });
+});
+
+function toolErrText(result: { content?: Array<{ type: string; text?: string }> }): string {
+  return result.content?.[0]?.type === "text" ? result.content[0].text ?? "Server error" : "Server error";
+}
+
+async function submitBatch() {
+  nextBtn.disabled = true;
+  setStatus("Submitting results to Lichess…");
+  try {
+    const result = await handle.app.callServerTool({
+      name: "submit_puzzle_batch",
+      arguments: {
+        angle: state.session.angle,
+        solutions: state.attempts.map((a) => ({ id: a.id, win: a.win, rated: true })),
+      },
+    });
+    if (result.isError) throw new Error(toolErrText(result));
+    const text = result.content?.[0]?.type === "text" ? result.content[0].text ?? "{}" : "{}";
+    const data = JSON.parse(text) as PuzzleSubmitResult;
+    showResults(data);
+  } catch (err) {
+    setStatus(`Failed to submit: ${(err as Error).message}`, "err");
+    nextBtn.disabled = false;
+  }
+}
+
+function showResults(data: PuzzleSubmitResult) {
+  state.done = true;
+  controlsEl.style.display = "none";
+  setStatus("");
+  resultsEl.style.display = "";
+
+  const totalDelta = (data.rounds ?? []).reduce(
+    (sum, r) => sum + (r.ratingDiff ?? 0),
+    0,
+  );
+
+  const newRating = data.glicko?.rating;
+  const sign = totalDelta >= 0 ? "+" : "";
+  const headline = newRating
+    ? `New puzzle rating: ${Math.round(newRating)} (${sign}${totalDelta})`
+    : `Net change: ${sign}${totalDelta}`;
+
+  const rounds = data.rounds ?? [];
+
+  resultsEl.innerHTML = "";
+  const h = document.createElement("div");
+  h.className = "status ok";
+  h.textContent = headline;
+  resultsEl.appendChild(h);
+
+  const list = document.createElement("ul");
+  list.className = "move-list";
+  for (let i = 0; i < rounds.length; i++) {
+    const r = rounds[i];
+    const li = document.createElement("li");
+    const left = document.createElement("span");
+    left.textContent = `${i + 1}. ${r.id} ${r.win ? "✓" : "✗"}`;
+    const right = document.createElement("span");
+    const rd = r.ratingDiff ?? 0;
+    right.textContent = `${rd >= 0 ? "+" : ""}${rd}`;
+    right.style.color = rd >= 0 ? "var(--accent)" : "var(--error)";
+    li.append(left, right);
+    list.appendChild(li);
+  }
+  resultsEl.appendChild(list);
+
+  const newSession = document.createElement("div");
+  newSession.className = "controls";
+  newSession.style.marginTop = "10px";
+  const startBtn = document.createElement("button");
+  startBtn.className = "primary";
+  startBtn.textContent = "Start another rated session";
+  startBtn.addEventListener("click", async () => {
+    startBtn.disabled = true;
+    setStatus("Loading new session…");
+    try {
+      const result = await handle.app.callServerTool({
+        name: "play_puzzle",
+        arguments: {
+          rated: true,
+          angle: state.session.angle,
+          nb: state.queue.length,
+        },
+      });
+      if (result.isError) throw new Error(toolErrText(result));
+      const props = extractUiProps<PuzzleProps>(result);
+      if (props) loadProps(props);
+      else {
+        setStatus("Server returned no puzzle props.", "err");
+        startBtn.disabled = false;
+      }
+    } catch (err) {
+      setStatus(`Failed to start: ${(err as Error).message}`, "err");
+      startBtn.disabled = false;
+    }
+  });
+  newSession.appendChild(startBtn);
+  resultsEl.appendChild(newSession);
+}
+
+function showUnratedDone() {
+  state.done = true;
+  setStatus("Batch complete. (Unrated — no rating change.)", "ok");
+  nextBtn.disabled = true;
+}
+
+handle.onUpdate(loadProps);
+loadProps(handle.props);

--- a/src/ui/shared/app-bootstrap.ts
+++ b/src/ui/shared/app-bootstrap.ts
@@ -1,0 +1,69 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { App } from "@modelcontextprotocol/ext-apps";
+import { UI_META_KEY } from "../../types/ui-props.js";
+
+export interface AppHandle<P> {
+  app: App;
+  props: P;
+  /** Subscribe to host-pushed tool-result notifications (re-invoke from chat). */
+  onUpdate(handler: (props: P) => void): void;
+}
+
+/**
+ * Pull the `_meta["modelcontextprotocol.io/ui"].props` payload off a tool
+ * result. Used by iframes that initiate their own callServerTool — those
+ * resolve via the request promise, not the toolresult event.
+ */
+export function extractUiProps<P>(result: CallToolResult): P | undefined {
+  const meta = (result as { _meta?: Record<string, unknown> })._meta;
+  const ui = meta?.[UI_META_KEY] as { props?: P } | undefined;
+  return ui?.props;
+}
+
+/**
+ * Connect to the host, wait for the initial tool-result, and return its props.
+ *
+ * Per the SDK warning, event listeners are wired before `connect()` so we don't
+ * miss the very first `tool-result` that opened the iframe.
+ */
+export async function bootstrap<P>(name: string): Promise<AppHandle<P>> {
+  const app = new App({ name, version: "0.2.0" });
+
+  const subscribers: Array<(p: P) => void> = [];
+  let resolveInitial!: (props: P) => void;
+  let rejectInitial!: (err: unknown) => void;
+  const initial = new Promise<P>((res, rej) => {
+    resolveInitial = res;
+    rejectInitial = rej;
+  });
+  let received = false;
+
+  app.ontoolresult = (params) => {
+    const meta = (params as { _meta?: Record<string, unknown> })._meta;
+    const ui = meta?.[UI_META_KEY] as { props?: P } | undefined;
+    const props = ui?.props;
+    if (!props) return;
+    if (!received) {
+      received = true;
+      resolveInitial(props);
+    } else {
+      for (const s of subscribers) s(props);
+    }
+  };
+
+  // Surface tool errors so the iframe can render a friendly message.
+  setTimeout(() => {
+    if (!received) rejectInitial(new Error("No initial UI props received"));
+  }, 10_000);
+
+  await app.connect();
+  const props = await initial;
+
+  return {
+    app,
+    props,
+    onUpdate(h) {
+      subscribers.push(h);
+    },
+  };
+}

--- a/src/ui/shared/board.ts
+++ b/src/ui/shared/board.ts
@@ -1,0 +1,61 @@
+import { Chessground } from "chessground";
+import type { Api } from "chessground/api";
+import type { Config } from "chessground/config";
+import type { Color, Dests, Key } from "chessground/types";
+import { Chess } from "chess.js";
+
+import "chessground/assets/chessground.base.css";
+import "chessground/assets/chessground.brown.css";
+import "chessground/assets/chessground.cburnett.css";
+
+export type { Color, Dests, Key };
+
+export function legalDestsFor(fen: string): Dests {
+  const chess = new Chess(fen);
+  const dests: Dests = new Map();
+  for (const m of chess.moves({ verbose: true }) as Array<{ from: Key; to: Key }>) {
+    const list = dests.get(m.from) ?? [];
+    list.push(m.to);
+    dests.set(m.from, list);
+  }
+  return dests;
+}
+
+export function turnColor(fen: string): Color {
+  // FEN side-to-move is the field after the position: "w" or "b".
+  return fen.split(" ")[1] === "w" ? "white" : "black";
+}
+
+export function makeBoard(el: HTMLElement, override: Config = {}): Api {
+  const defaults: Config = {
+    coordinates: true,
+    coordinatesOnSquares: false,
+    animation: { enabled: true, duration: 200 },
+    highlight: { lastMove: true, check: true },
+    drawable: { enabled: true, visible: true },
+    movable: { free: false, showDests: true, color: undefined },
+    premovable: { enabled: false },
+    draggable: { showGhost: true },
+  };
+  return Chessground(el, { ...defaults, ...override });
+}
+
+/**
+ * Convert a chess.js verbose move to UCI form (e2e4, e7e8q).
+ */
+export function toUci(from: Key, to: Key, promotion?: string): string {
+  return promotion ? `${from}${to}${promotion}` : `${from}${to}`;
+}
+
+/**
+ * Apply a UCI move on top of `fen`. Returns the resulting FEN, or null if
+ * the move was illegal.
+ */
+export function applyUci(fen: string, uci: string): string | null {
+  const chess = new Chess(fen);
+  const from = uci.slice(0, 2) as Key;
+  const to = uci.slice(2, 4) as Key;
+  const promotion = uci.length > 4 ? uci.slice(4, 5) : undefined;
+  const move = chess.move({ from, to, promotion });
+  return move ? chess.fen() : null;
+}

--- a/src/ui/shared/theme.css
+++ b/src/ui/shared/theme.css
@@ -1,0 +1,339 @@
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --muted: #6b6b6b;
+  --accent: #629924;
+  --error: #c64545;
+  --panel: #f5f5f4;
+  --border: #d6d3d1;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #161512;
+    --fg: #e6e2da;
+    --muted: #9a958b;
+    --accent: #759900;
+    --error: #d36446;
+    --panel: #262421;
+    --border: #3d3a35;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-sans, system-ui, -apple-system, "Segoe UI", sans-serif);
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 14px;
+  overflow-x: hidden;
+}
+
+#app {
+  display: flex;
+  gap: 16px;
+  padding: 12px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.board-wrap {
+  position: relative;
+  flex: 1 1 320px;
+  width: min(100%, 480px);
+  max-width: 100%;
+  min-width: 0;
+  aspect-ratio: 1 / 1;
+  box-sizing: border-box;
+}
+
+.promo-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 100;
+  background: color-mix(in srgb, var(--bg) 55%, transparent);
+  container-type: inline-size;
+}
+
+.promo-piece {
+  position: absolute;
+  width: 12.5%;
+  height: 12.5%;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9cqw;
+  line-height: 1;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.promo-piece:hover {
+  background: var(--border);
+}
+
+.cg-wrap {
+  width: 100%;
+  height: 100%;
+}
+
+.board-wrap .cg-wrap coords {
+  z-index: 4;
+  opacity: 0.9;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
+}
+
+.board-wrap .cg-wrap coords.ranks {
+  top: 0;
+  right: 3px;
+  bottom: 0;
+  left: auto;
+  width: 12px;
+  height: 100%;
+  align-items: flex-end;
+}
+
+.board-wrap .cg-wrap coords.ranks.left {
+  right: auto;
+  left: 3px;
+  align-items: flex-start;
+}
+
+.board-wrap .cg-wrap coords.ranks coord {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  transform: none;
+}
+
+.board-wrap .cg-wrap coords.ranks.left coord {
+  justify-content: flex-start;
+}
+
+.board-wrap .cg-wrap coords.files {
+  right: 0;
+  bottom: 2px;
+  left: 0;
+  width: 100%;
+  height: 12px;
+  text-align: left;
+  text-transform: lowercase;
+}
+
+.board-wrap .cg-wrap coords.files coord {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  padding-left: 3px;
+}
+
+.panel {
+  flex: 1 1 240px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.panel h3 {
+  margin: 0;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.panel .meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.controls {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+button {
+  font: inherit;
+  padding: 6px 12px;
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+button:hover:not(:disabled) {
+  background: var(--border);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+button.primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.status {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-weight: 500;
+  min-height: 1.5em;
+}
+
+.status.ok {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+}
+
+.status.err {
+  background: color-mix(in srgb, var(--error) 15%, transparent);
+  color: var(--error);
+}
+
+.move-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 320px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+}
+
+.move-list li {
+  padding: 4px 10px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.move-list li:last-child {
+  border-bottom: none;
+}
+
+.move-list li.current {
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+.move-list li:hover:not(.current) {
+  background: var(--border);
+}
+
+.pgn-move-list li {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0;
+  align-items: stretch;
+  padding: 0;
+  cursor: default;
+}
+
+.pgn-move-list li:hover:not(.current) {
+  background: transparent;
+}
+
+.pgn-move-number,
+.pgn-move {
+  min-width: 0;
+  padding: 5px 8px;
+  line-height: 1.25;
+}
+
+.pgn-move-number {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.pgn-move {
+  appearance: none;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+button.pgn-move:hover:not(:disabled) {
+  background: var(--border);
+}
+
+button.pgn-move.current {
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+button.pgn-move:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.pgn-move-placeholder {
+  cursor: default;
+}
+
+.bar {
+  display: flex;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--border);
+  min-width: 80px;
+}
+
+.bar > span {
+  display: block;
+  height: 100%;
+}
+
+.bar > .w {
+  background: #f0d9b5;
+}
+
+.bar > .d {
+  background: #888888;
+}
+
+.bar > .b {
+  background: #312e2b;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -30,4 +30,30 @@ describe("tool registry", () => {
       expect(typeof t.handler, `${t.name} handler is not a function`).toBe("function");
     }
   });
+
+  it("iframe-bearing ui descriptors point at known htmlFile names with ui:// resourceUris", () => {
+    const iframeTools = allTools.filter((t) => t.ui?.resourceUri);
+    expect(iframeTools.length).toBeGreaterThan(0);
+    for (const t of iframeTools) {
+      expect(t.ui!.resourceUri!.startsWith("ui://"), `${t.name} resourceUri must start with ui://`).toBe(true);
+      expect(t.ui!.htmlFile, `${t.name} with resourceUri must also set htmlFile`).toBeTruthy();
+      expect(t.ui!.htmlFile!.endsWith(".html"), `${t.name} htmlFile must end with .html`).toBe(true);
+    }
+  });
+
+  it("ui visibility entries are 'model' or 'app', and at least one tool is app-only", () => {
+    const visibilityTools = allTools.filter((t) => t.ui?.visibility);
+    for (const t of visibilityTools) {
+      for (const v of t.ui!.visibility!) {
+        expect(["model", "app"], `${t.name} has invalid visibility ${v}`).toContain(v);
+      }
+    }
+    const appOnly = allTools.filter(
+      (t) => t.ui?.visibility?.length === 1 && t.ui.visibility[0] === "app",
+    );
+    expect(
+      appOnly.length,
+      "expected at least one app-only tool (e.g. submit_puzzle_batch) — visibility:['app'] guards iframe-only writes",
+    ).toBeGreaterThan(0);
+  });
 });

--- a/tests/tools/apps/explore-openings.test.ts
+++ b/tests/tools/apps/explore-openings.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  installFetchMock,
+  makeContext,
+  findTool,
+} from "../../helpers/mock.js";
+import type {
+  ExplorerData,
+  OpeningsProps,
+  UiToolResult,
+} from "../../../src/types/ui-props.js";
+
+const EXPLORER_BASE = "https://explorer.lichess.org";
+const STARTING_FEN =
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const EMPTY_DATA: ExplorerData = {
+  white: 100,
+  draws: 50,
+  black: 80,
+  moves: [
+    { uci: "e2e4", san: "e4", white: 60, draws: 30, black: 40 },
+    { uci: "d2d4", san: "d4", white: 40, draws: 20, black: 40 },
+  ],
+  topGames: [
+    {
+      id: "G1",
+      uci: "e2e4",
+      winner: "white",
+      white: { name: "Carlsen", rating: 2830 },
+      black: { name: "Nepomniachtchi", rating: 2790 },
+      year: 2024,
+    },
+  ],
+  opening: { eco: "B00", name: "Random Opening" },
+};
+
+describe("explore_openings", () => {
+  it("is registered with a UI descriptor", () => {
+    const t = findTool("explore_openings");
+    expect(t.ui).toEqual({
+      resourceUri: "ui://lichess-mcp/openings.html",
+      htmlFile: "openings.html",
+    });
+  });
+
+  it("defaults to masters source and the starting position", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(EMPTY_DATA);
+
+    const result = (await findTool("explore_openings").handler(
+      { source: "masters" },
+      makeContext(),
+    )) as UiToolResult<OpeningsProps>;
+
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toContain(`${EXPLORER_BASE}/masters`);
+    const search = new URLSearchParams((url as string).split("?")[1]);
+    expect(search.get("fen")).toBe(STARTING_FEN);
+    expect(result.props.rootFen).toBe(STARTING_FEN);
+    expect(result.props.play).toBe("");
+    expect(result.props.currentFen).toBe(STARTING_FEN);
+    expect(result.props.source).toBe("masters");
+    expect(result.props.initialData.opening?.name).toBe("Random Opening");
+  });
+
+  it("hits the lichess endpoint when source is 'lichess'", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(EMPTY_DATA);
+
+    await findTool("explore_openings").handler(
+      { source: "lichess" },
+      makeContext(),
+    );
+
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toContain(`${EXPLORER_BASE}/lichess`);
+  });
+
+  it("threads play UCIs into the request and updates currentFen", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(EMPTY_DATA);
+
+    const result = (await findTool("explore_openings").handler(
+      { play: "e2e4,e7e5", source: "masters" },
+      makeContext(),
+    )) as UiToolResult<OpeningsProps>;
+
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toContain("play=e2e4%2Ce7e5");
+    expect(result.props.play).toBe("e2e4,e7e5");
+    // After 1.e4 e5 white moves next → side to move "w".
+    expect(result.props.currentFen.split(" ")[1]).toBe("w");
+    expect(result.props.currentFen).not.toBe(STARTING_FEN);
+  });
+
+  it("rejects illegal play sequences", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(EMPTY_DATA);
+
+    await expect(
+      findTool("explore_openings").handler(
+        { play: "e2e5", source: "masters" }, // pawn cannot e2→e5
+        makeContext(),
+      ),
+    ).rejects.toThrow(/Invalid|Illegal/);
+  });
+
+  it("text fallback summarizes top moves and source", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(EMPTY_DATA);
+
+    const result = (await findTool("explore_openings").handler(
+      { source: "masters" },
+      makeContext(),
+    )) as UiToolResult<OpeningsProps>;
+
+    expect(result.text).toContain("Random Opening");
+    expect(result.text).toContain("Source: masters");
+    expect(result.text).toContain("Top moves:");
+    expect(result.text).toContain("e4");
+    expect(result.text).toContain("d4");
+  });
+});

--- a/tests/tools/apps/play-puzzle.test.ts
+++ b/tests/tools/apps/play-puzzle.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  installFetchMock,
+  makeContext,
+  findTool,
+  expectFetch,
+  apiUrl,
+} from "../../helpers/mock.js";
+import type { UiToolResult, PuzzleProps } from "../../../src/types/ui-props.js";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+interface PuzzlePayload {
+  game: { id: string; pgn: string };
+  puzzle: {
+    id: string;
+    initialPly: number;
+    fen?: string;
+    solution: string[];
+    themes: string[];
+    rating: number;
+  };
+}
+
+function makePuzzlePayload(overrides: Partial<PuzzlePayload> = {}): PuzzlePayload {
+  return {
+    game: { id: "abcdefgh", pgn: "1. e4 e5 2. Nf3 Nc6 3. Bb5" },
+    puzzle: {
+      id: "PUZ01",
+      initialPly: 4,
+      solution: ["a7a6", "b5a4", "g8f6"],
+      themes: ["opening", "fork"],
+      rating: 1500,
+    },
+    ...overrides,
+  };
+}
+
+describe("play_puzzle (single mode)", () => {
+  it("is registered with a UI descriptor pointing to the puzzle resource", () => {
+    const t = findTool("play_puzzle");
+    expect(t.ui).toEqual({
+      resourceUri: "ui://lichess-mcp/puzzle.html",
+      htmlFile: "puzzle.html",
+    });
+  });
+
+  it("GETs /puzzle/daily by default", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(makePuzzlePayload());
+    await findTool("play_puzzle").handler({}, makeContext());
+    expectFetch(mock, { method: "GET", url: apiUrl("/puzzle/daily") });
+  });
+
+  it("GETs /puzzle/next when next:true", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(makePuzzlePayload());
+    await findTool("play_puzzle").handler({ next: true }, makeContext());
+    expectFetch(mock, { method: "GET", url: apiUrl("/puzzle/next") });
+  });
+
+  it("GETs /puzzle/{id} when an id is provided", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(makePuzzlePayload());
+    await findTool("play_puzzle").handler({ puzzleId: "Bmfot" }, makeContext());
+    expectFetch(mock, { method: "GET", url: apiUrl("/puzzle/Bmfot") });
+  });
+
+  it("returns puzzles[1] with computed FEN/orientation and unrated session", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(makePuzzlePayload());
+
+    const result = (await findTool("play_puzzle").handler(
+      {},
+      makeContext(),
+    )) as UiToolResult<PuzzleProps>;
+
+    expect(result.__uiResult).toBe(true);
+    expect(result.props.puzzles).toHaveLength(1);
+    const spec = result.props.puzzles[0];
+    expect(spec.puzzleId).toBe("PUZ01");
+    expect(spec.solution).toEqual(["a7a6", "b5a4", "g8f6"]);
+    expect(spec.rating).toBe(1500);
+    expect(spec.themes).toEqual(["opening", "fork"]);
+    expect(spec.lichessUrl).toBe("https://lichess.org/training/PUZ01");
+    // After 1.e4 e5 2.Nf3 Nc6 3.Bb5 black is to move.
+    expect(spec.orientation).toBe("black");
+    expect(spec.fen.split(" ")[1]).toBe("b");
+    expect(result.props.session).toEqual({ angle: "", rated: false });
+  });
+
+  it("prefers puzzle.fen from the API over PGN reconstruction when present", async () => {
+    const mock = installFetchMock();
+    const explicitFen = "8/8/8/8/8/8/8/4K2k w - - 0 1";
+    mock.respondJson(
+      makePuzzlePayload({
+        puzzle: {
+          id: "FENWINS",
+          initialPly: 4,
+          fen: explicitFen,
+          solution: ["e1e2"],
+          themes: [],
+          rating: 1234,
+        },
+      }),
+    );
+    const result = (await findTool("play_puzzle").handler(
+      {},
+      makeContext(),
+    )) as UiToolResult<PuzzleProps>;
+    expect(result.props.puzzles[0].fen).toBe(explicitFen);
+    expect(result.props.puzzles[0].orientation).toBe("white");
+  });
+
+  it("computes orientation 'white' when initialPly leaves white to move", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(
+      makePuzzlePayload({
+        game: { id: "g", pgn: "1. e4 e5" },
+        puzzle: {
+          id: "WHT01",
+          initialPly: 1,
+          solution: ["g1f3"],
+          themes: [],
+          rating: 1000,
+        },
+      }),
+    );
+
+    const result = (await findTool("play_puzzle").handler(
+      {},
+      makeContext(),
+    )) as UiToolResult<PuzzleProps>;
+
+    expect(result.props.puzzles[0].orientation).toBe("white");
+    expect(result.props.puzzles[0].fen.split(" ")[1]).toBe("w");
+  });
+
+  it("text fallback includes id, rating, themes, FEN, and lichess link", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(makePuzzlePayload());
+    const result = (await findTool("play_puzzle").handler(
+      {},
+      makeContext(),
+    )) as UiToolResult<PuzzleProps>;
+    expect(result.text).toContain("Puzzle PUZ01");
+    expect(result.text).toContain("rating 1500");
+    expect(result.text).toContain("opening, fork");
+    expect(result.text).toContain("https://lichess.org/training/PUZ01");
+    expect(result.text).toContain("FEN:");
+    expect(result.text).toContain("Solution (UCI):");
+  });
+
+  it("encodes puzzle id in the URL", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(makePuzzlePayload());
+    await findTool("play_puzzle").handler({ puzzleId: "a/b c" }, makeContext());
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toContain("a%2Fb%20c");
+  });
+
+  it("names the puzzle id when its PGN fails to parse", async () => {
+    const mock = installFetchMock();
+    mock.respondJson(
+      makePuzzlePayload({
+        game: { id: "g", pgn: '[Event "x"]\n1. zz' },
+        puzzle: {
+          id: "BADPGN",
+          initialPly: 0,
+          solution: ["a2a4"],
+          themes: [],
+          rating: 1000,
+        },
+      }),
+    );
+
+    await expect(
+      findTool("play_puzzle").handler({}, makeContext()),
+    ).rejects.toThrow(/Puzzle BADPGN has an invalid PGN/);
+  });
+});
+
+describe("play_puzzle (rated batch mode)", () => {
+  it("GETs /puzzle/batch/{angle}?nb=N with nb defaulting to 10 and angle to mix", async () => {
+    const mock = installFetchMock();
+    mock.respondJson({
+      puzzles: [makePuzzlePayload(), makePuzzlePayload({ puzzle: { ...makePuzzlePayload().puzzle, id: "PUZ02" } })],
+    });
+
+    await findTool("play_puzzle").handler({ rated: true }, makeContext());
+
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toBe(apiUrl("/puzzle/batch/mix?nb=10"));
+  });
+
+  it("threads angle, nb, difficulty into the request", async () => {
+    const mock = installFetchMock();
+    mock.respondJson({ puzzles: [makePuzzlePayload()] });
+
+    await findTool("play_puzzle").handler(
+      { rated: true, angle: "endgame", nb: 5, difficulty: "harder" },
+      makeContext(),
+    );
+
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toContain("/puzzle/batch/endgame");
+    expect(url).toContain("nb=5");
+    expect(url).toContain("difficulty=harder");
+  });
+
+  it("returns puzzles[N] with rated session matching the requested angle", async () => {
+    const mock = installFetchMock();
+    mock.respondJson({
+      puzzles: [
+        makePuzzlePayload({
+          puzzle: { id: "P1", initialPly: 0, solution: ["e2e4"], themes: [], rating: 1500 },
+          game: { id: "g1", pgn: "" },
+        }),
+        makePuzzlePayload({
+          puzzle: { id: "P2", initialPly: 0, solution: ["d2d4"], themes: [], rating: 1600 },
+          game: { id: "g2", pgn: "" },
+        }),
+      ],
+    });
+
+    const result = (await findTool("play_puzzle").handler(
+      { rated: true, angle: "endgame", nb: 2 },
+      makeContext(),
+    )) as UiToolResult<PuzzleProps>;
+
+    expect(result.props.puzzles).toHaveLength(2);
+    expect(result.props.puzzles[0].puzzleId).toBe("P1");
+    expect(result.props.puzzles[1].puzzleId).toBe("P2");
+    expect(result.props.session).toEqual({ angle: "endgame", rated: true });
+  });
+
+  it("text fallback lists each puzzle's id, rating, and lichess link", async () => {
+    const mock = installFetchMock();
+    mock.respondJson({
+      puzzles: [
+        makePuzzlePayload({
+          puzzle: { id: "P1", initialPly: 0, solution: ["e2e4"], themes: [], rating: 1500 },
+          game: { id: "g1", pgn: "" },
+        }),
+      ],
+    });
+
+    const result = (await findTool("play_puzzle").handler(
+      { rated: true, nb: 1 },
+      makeContext(),
+    )) as UiToolResult<PuzzleProps>;
+
+    expect(result.text).toContain("Rated batch:");
+    expect(result.text).toContain("angle mix");
+    expect(result.text).toContain("P1");
+    expect(result.text).toContain("https://lichess.org/training/P1");
+  });
+
+  it("only honors color when nb=1", async () => {
+    const mock = installFetchMock();
+    mock.respondJson({ puzzles: [] });
+    await findTool("play_puzzle").handler(
+      { rated: true, nb: 5, color: "white" },
+      makeContext(),
+    );
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).not.toContain("color=white");
+
+    mock.mockReset();
+    mock.respondJson({ puzzles: [] });
+    await findTool("play_puzzle").handler(
+      { rated: true, nb: 1, color: "white" },
+      makeContext(),
+    );
+    const [url2] = mock.mock.calls[0] as [string, unknown];
+    expect(url2).toContain("color=white");
+  });
+});

--- a/tests/tools/apps/submit-puzzle-batch.test.ts
+++ b/tests/tools/apps/submit-puzzle-batch.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  installFetchMock,
+  makeContext,
+  findTool,
+  apiUrl,
+} from "../../helpers/mock.js";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("submit_puzzle_batch", () => {
+  it("is registered as an app-only callback (visibility ['app'], no iframe resource)", () => {
+    const t = findTool("submit_puzzle_batch");
+    expect(t.ui?.visibility).toEqual(["app"]);
+    expect(t.ui?.resourceUri).toBeUndefined();
+    expect(t.ui?.htmlFile).toBeUndefined();
+  });
+
+  it("POSTs the spec body shape {solutions:[{id,win,rated}]} to /puzzle/batch/{angle}", async () => {
+    const mock = installFetchMock();
+    mock.respondJson({
+      rounds: [{ id: "P1", win: true, ratingDiff: 5 }],
+      glicko: { rating: 1505, deviation: 80 },
+    });
+
+    await findTool("submit_puzzle_batch").handler(
+      {
+        angle: "mix",
+        solutions: [
+          { id: "P1", win: true },
+          { id: "P2", win: false, rated: false },
+        ],
+      },
+      makeContext(),
+    );
+
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit & { headers: Headers }];
+    expect(url).toBe(apiUrl("/puzzle/batch/mix"));
+    expect(init.method).toBe("POST");
+    expect(init.headers.get("Content-Type")).toBe("application/json");
+    const body = JSON.parse(init.body as string);
+    expect(body.solutions).toEqual([
+      { id: "P1", win: true, rated: true },
+      { id: "P2", win: false, rated: false },
+    ]);
+  });
+
+  it("returns the parsed Lichess response (rounds + glicko)", async () => {
+    const mock = installFetchMock();
+    const payload = {
+      rounds: [{ id: "P1", win: true, ratingDiff: 5 }],
+      glicko: { rating: 1505, deviation: 80 },
+    };
+    mock.respondJson(payload);
+
+    const result = await findTool("submit_puzzle_batch").handler(
+      {
+        angle: "mix",
+        solutions: [{ id: "P1", win: true }],
+      },
+      makeContext(),
+    );
+
+    expect(result).toEqual(payload);
+  });
+
+  it("encodes the angle in the URL", async () => {
+    const mock = installFetchMock();
+    mock.respondJson({});
+    await findTool("submit_puzzle_batch").handler(
+      {
+        angle: "queen sacrifice",
+        solutions: [{ id: "X", win: true }],
+      },
+      makeContext(),
+    );
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toContain("queen%20sacrifice");
+  });
+
+  it("rejects empty solutions array", () => {
+    const t = findTool("submit_puzzle_batch");
+    expect(() => t.schema.parse({ angle: "mix", solutions: [] })).toThrow();
+  });
+});

--- a/tests/tools/apps/view-pgn.test.ts
+++ b/tests/tools/apps/view-pgn.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  installFetchMock,
+  makeContext,
+  findTool,
+  lichessUrl,
+} from "../../helpers/mock.js";
+import type { UiToolResult, PgnProps } from "../../../src/types/ui-props.js";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const SAMPLE_PGN = `[Event "World Championship"]
+[Site "London"]
+[Date "2024.12.01"]
+[White "Carlsen, M"]
+[Black "Nepomniachtchi, I"]
+[WhiteElo "2830"]
+[BlackElo "2790"]
+[Result "1-0"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 1-0
+`;
+
+describe("view_pgn", () => {
+  it("is registered with a UI descriptor", () => {
+    const t = findTool("view_pgn");
+    expect(t.ui).toEqual({
+      resourceUri: "ui://lichess-mcp/pgn.html",
+      htmlFile: "pgn.html",
+    });
+  });
+
+  it("uses the provided PGN verbatim without fetching", async () => {
+    const mock = installFetchMock();
+
+    const result = (await findTool("view_pgn").handler(
+      { pgn: SAMPLE_PGN },
+      makeContext(),
+    )) as UiToolResult<PgnProps>;
+
+    expect(mock).not.toHaveBeenCalled();
+    expect(result.__uiResult).toBe(true);
+    expect(result.props.pgn).toBe(SAMPLE_PGN);
+    expect(result.props.lichessUrl).toBeNull();
+  });
+
+  it("fetches /game/export/{gameId} when only gameId provided", async () => {
+    const mock = installFetchMock();
+    mock.respondPgn(SAMPLE_PGN);
+
+    const result = (await findTool("view_pgn").handler(
+      { gameId: "abc12345" },
+      makeContext(),
+    )) as UiToolResult<PgnProps>;
+
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit & { headers: Headers }];
+    expect(url).toBe(lichessUrl("/game/export/abc12345"));
+    expect(init.headers.get("Accept")).toBe("application/x-chess-pgn");
+    expect(result.props.pgn).toBe(SAMPLE_PGN);
+    expect(result.props.lichessUrl).toBe("https://lichess.org/abc12345");
+  });
+
+  it("extracts standard PGN headers", async () => {
+    const result = (await findTool("view_pgn").handler(
+      { pgn: SAMPLE_PGN },
+      makeContext(),
+    )) as UiToolResult<PgnProps>;
+
+    expect(result.props.headers.event).toBe("World Championship");
+    expect(result.props.headers.white).toBe("Carlsen, M");
+    expect(result.props.headers.black).toBe("Nepomniachtchi, I");
+    expect(result.props.headers.whiteElo).toBe("2830");
+    expect(result.props.headers.blackElo).toBe("2790");
+    expect(result.props.headers.result).toBe("1-0");
+    expect(result.props.headers.date).toBe("2024.12.01");
+    expect(result.props.headers.site).toBe("London");
+  });
+
+  it("extracts FEN and SetUp headers for setup-position PGNs", async () => {
+    const setupPgn = `[Event "Endgame Study"]
+[SetUp "1"]
+[FEN "8/8/8/8/8/4k3/4P3/4K3 w - - 0 1"]
+
+1. Kd1 Kf4 *
+`;
+
+    const result = (await findTool("view_pgn").handler(
+      { pgn: setupPgn },
+      makeContext(),
+    )) as UiToolResult<PgnProps>;
+
+    expect(result.props.headers.setup).toBe("1");
+    expect(result.props.headers.fen).toBe("8/8/8/8/8/4k3/4P3/4K3 w - - 0 1");
+  });
+
+  it("text fallback includes player names, result, and the PGN body", async () => {
+    const result = (await findTool("view_pgn").handler(
+      { gameId: "abc12345", pgn: SAMPLE_PGN },
+      makeContext(),
+    )) as UiToolResult<PgnProps>;
+
+    expect(result.text).toContain("Carlsen, M (2830) vs Nepomniachtchi, I (2790)");
+    expect(result.text).toContain("Result: 1-0");
+    expect(result.text).toContain("https://lichess.org/abc12345");
+    expect(result.text).toContain("1. e4 e5");
+  });
+
+  it("truncates long PGN text fallback to 800 chars + ellipsis", async () => {
+    const longPgn = `[Event "${"Long Match ".repeat(100)}"]
+[Result "1-0"]
+
+1. e4 e5 1-0
+`;
+
+    const result = (await findTool("view_pgn").handler(
+      { pgn: longPgn },
+      makeContext(),
+    )) as UiToolResult<PgnProps>;
+
+    expect(result.text).toContain("…");
+  });
+
+  it("rejects when neither gameId nor pgn is provided", () => {
+    const t = findTool("view_pgn");
+    expect(() => t.schema.parse({})).toThrow();
+  });
+
+  it("normalizes a path with perspective suffix to the bare 8-char id", async () => {
+    const mock = installFetchMock();
+    mock.respondPgn(SAMPLE_PGN);
+
+    await findTool("view_pgn").handler(
+      { gameId: "AxGa6qxX/black" },
+      makeContext(),
+    );
+
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toBe(lichessUrl("/game/export/AxGa6qxX"));
+  });
+
+  it("normalizes a full Lichess URL to the bare id", async () => {
+    const mock = installFetchMock();
+    mock.respondPgn(SAMPLE_PGN);
+
+    const result = (await findTool("view_pgn").handler(
+      { gameId: "https://lichess.org/AxGa6qxX/black" },
+      makeContext(),
+    )) as UiToolResult<PgnProps>;
+
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toBe(lichessUrl("/game/export/AxGa6qxX"));
+    expect(result.props.lichessUrl).toBe("https://lichess.org/AxGa6qxX");
+  });
+
+  it("accepts the 12-char full id and uses its 8-char prefix", async () => {
+    const mock = installFetchMock();
+    mock.respondPgn(SAMPLE_PGN);
+
+    await findTool("view_pgn").handler(
+      { gameId: "AxGa6qxXuvwX" },
+      makeContext(),
+    );
+
+    const [url] = mock.mock.calls[0] as [string, unknown];
+    expect(url).toBe(lichessUrl("/game/export/AxGa6qxX"));
+  });
+
+  it("rejects malformed game ids with a clear error", async () => {
+    await expect(
+      findTool("view_pgn").handler({ gameId: "not-a-real-id!" }, makeContext()),
+    ).rejects.toThrow(/not a Lichess game id/);
+  });
+
+  it("rejects a malformed raw PGN with a parse error and variant hint", async () => {
+    await expect(
+      findTool("view_pgn").handler(
+        { pgn: '[Event "x"]\n1. zz' },
+        makeContext(),
+      ),
+    ).rejects.toThrow(/Could not parse PGN.*standard chess and Chess960/s);
+  });
+
+  it("names the game id when a fetched PGN fails to parse", async () => {
+    const mock = installFetchMock();
+    mock.respondPgn('[Event "x"]\n1. zz');
+
+    await expect(
+      findTool("view_pgn").handler({ gameId: "abc12345" }, makeContext()),
+    ).rejects.toThrow(/Could not parse PGN for abc12345/);
+  });
+});

--- a/tests/tools/puzzles.test.ts
+++ b/tests/tools/puzzles.test.ts
@@ -108,14 +108,17 @@ describe("get_puzzle_batch", () => {
 });
 
 describe("solve_puzzle_batch", () => {
-  it("POSTs solutions JSON to /api/puzzle/batch/{angle}", async () => {
+  it("POSTs solutions JSON to /api/puzzle/batch/{angle} matching the spec body shape", async () => {
     const mock = installFetchMock();
-    mock.respondJson({ puzzles: [] });
+    mock.respondJson({ rounds: [] });
 
     await findTool("solve_puzzle_batch").handler(
       {
         angle: "mix",
-        solutions: [{ id: "abc", win: true, time: 3000 }],
+        solutions: [
+          { id: "abc", win: true },
+          { id: "def", win: false, rated: false },
+        ],
       },
       makeContext(),
     );
@@ -125,15 +128,18 @@ describe("solve_puzzle_batch", () => {
     expect(init.method).toBe("POST");
     expect(init.headers.get("Content-Type")).toBe("application/json");
     const body = JSON.parse(init.body as string);
-    expect(body.solutions[0].id).toBe("abc");
+    expect(body.solutions[0]).toEqual({ id: "abc", win: true, rated: true });
+    expect(body.solutions[1]).toEqual({ id: "def", win: false, rated: false });
+    // The deprecated `time` field must NOT be sent (it isn't in the spec).
+    expect(body.solutions[0]).not.toHaveProperty("time");
   });
 
   it("includes nb param in query string", async () => {
     const mock = installFetchMock();
-    mock.respondJson({ puzzles: [] });
+    mock.respondJson({ rounds: [] });
 
     await findTool("solve_puzzle_batch").handler(
-      { angle: "mix", solutions: [], nb: 10 },
+      { angle: "mix", solutions: [{ id: "x", win: true }], nb: 10 },
       makeContext(),
     );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/ui"]
 }

--- a/tsconfig.ui.json
+++ b/tsconfig.ui.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src/ui/**/*", "src/types/ui-props.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+import { resolve } from "node:path";
+
+const target = process.env.UI_TARGET;
+if (!target) {
+  throw new Error(
+    "vite.config.ts requires UI_TARGET (e.g. UI_TARGET=puzzle vite build)",
+  );
+}
+const ALLOWED = ["puzzle", "pgn", "openings"];
+if (!ALLOWED.includes(target)) {
+  throw new Error(
+    `Unknown UI_TARGET="${target}". Allowed: ${ALLOWED.join(", ")}`,
+  );
+}
+
+export default defineConfig({
+  root: resolve(__dirname, `src/ui/${target}`),
+  base: "./",
+  plugins: [viteSingleFile()],
+  build: {
+    outDir: resolve(__dirname, "build/ui"),
+    emptyOutDir: false,
+    assetsInlineLimit: Infinity,
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: resolve(__dirname, `src/ui/${target}/index.html`),
+      output: {
+        entryFileNames: `${target}.js`,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds three interactive iframe tools — `play_puzzle`, `view_pgn`, `explore_openings` — registered via `@modelcontextprotocol/ext-apps`, each shipping a self-contained Vite-built single-file HTML bundle (chessground + chess.js) with a text fallback for non-UI clients.
- Adds an app-only `submit_puzzle_batch` callback (`visibility: ["app"]`) so only the puzzle iframe can post solved batches back to Lichess; the model never sees this tool.
- Fixes `solve_puzzle_batch` to match the Lichess API spec (drops the unused `time` field, adds per-solution `rated`) and routes `/game/export/{id}` through `lichess.org` root instead of `/api`, which 404s.

## Changes
- New `UiAppDescriptor` on `ToolDefinition` + `UiToolResult<P>` discriminator; `server.ts` dispatches iframe tools to `registerAppTool`/`registerAppResource` and stamps `_meta["modelcontextprotocol.io/ui"].props` on returns.
- Shared UI scaffolding in `src/ui/shared/` (chessground board, theme, MCP-Apps bootstrap) consumed by `puzzle`, `pgn`, and `openings` entrypoints.
- `tsconfig.ui.json` for browser-only typing of the iframe sources; root `tsconfig.json` excludes `src/ui` so server build stays Node-only. `npm run build` now runs typecheck → UI bundle → server.
- Strict typing across the iframe ↔ server contract via `src/types/ui-props.ts`, imported by both sides.

## Test plan
- [x] `npm test` — 360 / 360 pass (added registry tests for the `ui` descriptor shape + 4 new app-tool test files)
- [x] `npm run typecheck` — clean for both server and UI tsconfigs
- [ ] Verify in Claude Desktop: `play_puzzle`, `view_pgn`, `explore_openings` render an interactive board; non-UI clients get the text fallback
- [ ] Verify `solve_puzzle_batch` round-trips through Lichess (rated + unrated paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)