### PR TITLE
fix(studies): send the permission fields create_study requires

### DIFF
--- a/src/tools/studies.ts
+++ b/src/tools/studies.ts
@@ -56,6 +56,11 @@ const getUserStudies = tool({
     client.ndjson(`/study/by/${encodeURIComponent(username)}`),
 });
 
+const studyPermission = z
+  .enum(["nobody", "owner", "contributor", "member", "everyone"])
+  .optional()
+  .default("everyone");
+
 const createStudy = tool({
   name: "create_study",
   description: "Create a new study",
@@ -66,9 +71,18 @@ const createStudy = tool({
       .optional()
       .default("unlisted")
       .describe("Who can view the study"),
+    explorer: studyPermission.describe("Who can use the opening explorer"),
+    computer: studyPermission.describe("Who can use computer analysis"),
+    chat: studyPermission.describe("Who can chat"),
+    shareable: studyPermission.describe("Who can share and export"),
+    cloneable: studyPermission.describe("Who can clone the study"),
   }),
-  handler: async ({ name, visibility }, { client }) => {
-    const response = await client.postForm("/study", { name, visibility });
+  handler: async ({ name, visibility, ...settings }, { client }) => {
+    const response = await client.postForm("/study", {
+      name,
+      visibility,
+      ...settings,
+    });
     return (await response.json()) as object;
   },
 });

--- a/tests/tools/studies.test.ts
+++ b/tests/tools/studies.test.ts
@@ -104,6 +104,20 @@ describe("create_study", () => {
   it("rejects name shorter than 2 chars (schema validation)", () => {
     expect(() => findTool("create_study").schema.parse({ name: "X" })).toThrow();
   });
+
+  it("sends the permission fields the API requires", async () => {
+    const mock = installFetchMock();
+    mock.respondJson({ id: "newStudy" });
+
+    const args = findTool("create_study").schema.parse({ name: "My Study" });
+    await findTool("create_study").handler(args, makeContext());
+
+    const [, init] = mock.mock.calls[0] as [string, RequestInit & { headers: Headers }];
+    const body = init.body?.toString() ?? "";
+    for (const field of ["explorer", "computer", "chat", "shareable", "cloneable"]) {
+      expect(body).toContain(`${field}=everyone`);
+    }
+  });
 });
 
 describe("import_study_pgn", () => {


### PR DESCRIPTION
## Problem

`create_study` fails on every call. `POST /api/study` rejects any request that omits `explorer`, `computer`, `chat`, `shareable` and `cloneable`:

```
{"error":{"explorer":["This field is required"],"computer":["This field is required"],"chat":["This field is required"],"shareable":["This field is required"],"cloneable":["This field is required"]}}
```

The tool only sends `name` and `visibility`, so it returns HTTP 400 regardless of input. Reproduce with any valid token:

```
create_study({ name: "My Study", visibility: "private" })
```

## Fix

Adds the five fields to the schema as optional enums defaulting to `everyone`, and forwards them to `postForm`. Defaults preserve the existing call signature, so `create_study({ name })` now succeeds instead of 400ing, and callers who want tighter settings can pass them.

Allowed values were confirmed against the live API rather than guessed. Sending four candidates alongside one deliberately invalid field makes the API reject the whole request while naming only the bad one, which enumerates the valid set without creating throwaway studies:

```
-d "explorer=nobody" -d "computer=owner" -d "chat=contributor" -d "shareable=member" -d "cloneable=BOGUS"
-> {"error":{"cloneable":["Invalid value: BOGUS"]}}
```

Valid set: `nobody`, `owner`, `contributor`, `member`, `everyone`.

## Testing

- `npm run typecheck` clean
- `npm test` 360 passing, including a new regression test asserting all five fields reach the request body
- Verified end to end against the live API: study created, then chapters imported with `import_study_pgn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)